### PR TITLE
18188. AttributeError: 'NoneType' object has no attribute 'rfind'

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -686,9 +686,14 @@ class DeviceSyncManager(object):
         count = size = 0
         for info in items:
             converter = self.conversion_for_info(info, )
-            if converter:
+            if converter == 'copy':
+                count += 1
+                size += info.size
+            elif converter:
                 task = conversions.conversion_manager._make_conversion_task(
-                    converter, info, None, False)
+                    converter, info,
+                    target_folder=None,
+                    create_item=False)
                 if task:
                     count += 1
                     size += task.get_output_size_guess()


### PR DESCRIPTION
If we're copying the file, don't bother creating a task to figure out the size;
just grab it from the ItemInfo.
