### PR TITLE
Bz18239

### DIFF
--- a/tv/lib/httpclient.py
+++ b/tv/lib/httpclient.py
@@ -552,7 +552,7 @@ class CurlTransfer(object):
         return False
 
 
-    def debug_func(self, type, msg):
+    def debug_func(self, typ, msg):
         type_map = {
                 pycurl.INFOTYPE_HEADER_IN: 'header-in',
                 pycurl.INFOTYPE_HEADER_OUT: 'header-out',
@@ -560,7 +560,7 @@ class CurlTransfer(object):
                 pycurl.INFOTYPE_DATA_OUT: 'data-out',
                 pycurl.INFOTYPE_TEXT: 'text',
         }
-        type_str = type_map.get(type, type)
+        type_str = type_map.get(typ, typ)
         logging.warn("libcurl debug (%s) %r", type_str, msg)
 
 


### PR DESCRIPTION
bz18239: Don't trust the HTTP HEAD response from the server too much.

We use the HTTP HEAD request to get a bit of info about the item before
proceeding to download but it doesn't always work.  Either the server
may not support it, or maybe it it returns some other status code
when the item's really there.

So, if it returned a response code that we did not expect and it was
a HEAD request, try to download anyway and let the download code deal
with failure.

BONUS!  Change a reserved word usage.  type -> typ.
