### PR TITLE
bz:18264: In httpclient, don't scribble filesystem on HTTP error.

### DIFF
--- a/tv/lib/test/httpclienttest.py
+++ b/tv/lib/test/httpclienttest.py
@@ -991,16 +991,22 @@ class NetworkErrorTest(HTTPClientTestBase):
             httpclient.ServerClosedConnection))
 
     @uses_httpclient
-    def test_404_error(self):
+    def test_404_error(self, write_file=None):
         self.expecting_errback = True
         url = self.httpserver.build_url('badfile.txt')
-        self.grab_url(url)
+        self.grab_url(url, write_file=write_file)
         self.assert_(isinstance(self.grab_url_error,
             httpclient.UnexpectedStatusCode))
         # FIXME: It'd be nice if we could check a HTTP code rather than a
         # static message.
         self.assertEquals(self.grab_url_error.friendlyDescription,
                 _("File not found"))
+        if write_file:
+            self.assertEquals(open(write_file).read(), '')
+
+    def test_error_nofile(self):
+        write_file = self.make_temp_path(".txt")
+        self.test_404_error(write_file=write_file)
 
     @uses_mock_httpclient
     def test_bad_domain_name(self):


### PR DESCRIPTION
In bz:18239, we changed the behavior of httpclient so that it does not
rely on HEAD, and tries to grab the file anyway.  Unfortunately, after
thinking more, that is prone to breakage too.  The problem is the
pycurl.WRITEDATA: it scribbles stuff regardless of what body you get,
so we can get data on successful fetch (good), or non-successful data (bad).
In the latter case it scribbles over the filesystem unnecessarily and
makes the system think you have downloaded a file when in fact the file
is bogus.  Before, this symptom was more rare since it can only happen
on the HEAD hack for specific HTTP error codes, now it can happen more often
since we try to do a fetch anyway regardless of what the HEAD said.

The fix is to use WRITEFUNCTION instead of WRITEDATA, and ensure we only
perform a write on data where the http code is recognized to be clean.
