### PR TITLE
bz18104.  Catch ValueError in next_free_{filename,directory}().

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -805,7 +805,15 @@ class DeviceSyncManager(object):
                 if os.path.exists(final_path):
                     logging.debug('%r exists, getting a new one precopy',
                                   final_path)
-                    final_path, fp = next_free_filename(final_path)
+                    try:
+                        final_path, fp = next_free_filename(final_path)
+                        # XXX we should be passing in the file handle not
+                        # path.
+                        fp.close()
+                    except ValueError:
+                        logging.warn('add_items: next_free_filename failed. '
+                                     'candidate = %r', final_path)
+                        continue
                 self.copy_file(info, final_path)
             else:
                 self.start_conversion(conversion,

--- a/tv/lib/iconcache.py
+++ b/tv/lib/iconcache.py
@@ -205,25 +205,32 @@ class IconCache(DDBObject):
                     tmp_filename = self.filename + ".part"
                 else:
                     tmp_filename = os.path.join(cachedir, info["filename"]) + ".part"
-
                 tmp_filename, output = next_free_filename(tmp_filename)
-
                 output.write(info["body"])
                 output.close()
             except IOError:
                 self.remove_file(tmp_filename)
+                return
+            except ValueError:
+                logging.warn('update_icon_cache: next_free_filename failed '
+                             '#1, candidate = %r', tmp_filename)
+                return
+
+            filename = unicode(info["filename"])
+            filename = unicode_to_filename(filename, cachedir)
+            filename = os.path.join(cachedir, filename)
+            needs_save = True
+            try:
+                filename, fp = next_free_filename(filename)
+            except ValueError:
+                logging.warn('update_icon_cache: next_free_filename failed '
+                             '#2, candidate = %r', filename)
                 return
 
             if self.filename:
                 filename = self.filename
                 self.filename = None
                 self.remove_file(filename)
-
-            filename = unicode(info["filename"])
-            filename = unicode_to_filename(filename, cachedir)
-            filename = os.path.join(cachedir, filename)
-            filename, fp = next_free_filename(filename)
-            needs_save = True
 
             # we need to move the file here--so we close the file
             # pointer and then move the file.


### PR DESCRIPTION
The next_free_{filename,directory}() functions can throw ValueError if
a set number tries exceed a threshold.  But, code using this does not
catch ValueError, leading to uncaught exception.  Worse, wrap these
around a @returns_filename decorator, which catches ValueError and
reraises ValueError with a different message, so the user/developer
is left confused as to why there is an apparent internal failure with
this suite of functions.

Note, I have been careful to address the following:

(0) Catching ValueError in the case of failure for next_free_filename() or next_free_directory(), though not always returning UI feedback which is obviously not ideal at the moment.  We do log such failures though, hopefully they are not that frequent.

(1) Only proceeding with the requested operation if such temporary filename/next_free_filename()/next_free_directory() succeeded.

(2) next_free_filename() returns a pathname and an open file handle, since this is the only way to ensure safe operation of creating a new file then writing to it (O_CREAT|O_EXCL).  We abuse this API sometimes when we use the pathname component in a file operation (such as a move).  This won't work on Windows as the currently open file will be deleted before the move happens and the deletion won't succeed due to the open file handle.  So as a workaround for the time being, we close it (fp.close()) before any move operation, but obviously this is not ideal.
