### PR TITLE
bz18288: Correctly pass function arguments.

### DIFF
--- a/tv/lib/storedatabase.py
+++ b/tv/lib/storedatabase.py
@@ -639,6 +639,7 @@ class LiveStorage:
                 value = self._converter.from_sql(schema, name, schema_item,
                         value)
             except StandardError:
+                logging.exception('self._converter.from_sql failed.')
                 handler = self._converter.get_malformed_data_handler(schema,
                         name, schema_item, value)
                 if handler is None:
@@ -1031,7 +1032,7 @@ class SQLiteConverter(object):
         return eval(value, __builtins__, {'datetime': datetime, 'time': _TIME_MODULE_SHADOW})
 
     def _status_from_sql(self, repr_value, schema_item):
-        status_dict = self._repr_from_sql(repr_value)
+        status_dict = self._repr_from_sql(repr_value, schema_item)
         filename_fields = schema.SchemaStatusContainer.filename_fields
         for key in filename_fields:
             value = status_dict.get(key)


### PR DESCRIPTION
We save the download status on shutdown.  But due to a TypeError due to
not passing in a required parameter in the function, it gets wiped,
because the restore mechanism falls back to a default due to an
exception being thrown.

This happens with all downloads.
