### PR TITLE
Catch exceptions when calling terminate() (#18172)

### DIFF
--- a/tv/lib/subprocessmanager.py
+++ b/tv/lib/subprocessmanager.py
@@ -381,7 +381,14 @@ class SubprocessManager(object):
         self.thread.join(timeout)
         # If things didn't shutdown, then force them to quit
         if self.process.returncode is None:
-            self.process.terminate()
+            try:
+                self.process.terminate()
+            except OSError, e:
+                # Error on terminate.  Normally we should log an error, except
+                # in the case where the process quit by itself before our
+                # terminate() call (see #18172).
+                if self.process.returncode is None:
+                    logging.exception("error calling terminate()")
         self._cleanup_process()
 
     def _on_thread_quit(self, thread):


### PR DESCRIPTION
I think the main way this happens is the process quits between when we check
the returncode attribute and when we call terminate().  In that case, don't
bother to log an error.
