### PR TITLE
Select SRT files correctly on windows after the overhaul changes (#18333)

### DIFF
--- a/tv/lib/frontends/widgets/gst/renderer.py
+++ b/tv/lib/frontends/widgets/gst/renderer.py
@@ -335,7 +335,8 @@ class VideoRenderer(Renderer):
                 self.enabled_track = 0
 
         if sub_filename:
-            self.playbin.set_property("suburi", "file://%s" % sub_filename)
+            self.playbin.set_property("suburi",
+                    gstutil._get_file_url(sub_filename))
         if sub_index > -1:
             flags = self.playbin.get_property('flags')
             self.playbin.set_properties(flags=flags | GST_PLAY_FLAG_TEXT,


### PR DESCRIPTION
Select SRT files correctly on windows after the overhaul changes (#18333)

If we pass in a file URL, we need to use gstutil._get_file_url().
