### PR TITLE
Address point (b) of bz17155

### DIFF
--- a/tv/lib/dl_daemon/command.py
+++ b/tv/lib/dl_daemon/command.py
@@ -114,6 +114,23 @@ class UpdateDownloadStatus(Command):
         from miro.downloader import RemoteDownloader
         return RemoteDownloader.update_status(*self.args, **self.kws)
 
+# DownloaderSyncRequest/DownloaderSyncNotify: what are these?
+#
+# They are used to as a notification.  Usage: DownloaderSyncRequest command
+# is sent to the downloader and when it is received the downloader sends
+# DownloaderSyncNotify.  Thus, when a DownloaderSyncNotify is received,
+# you can be sure that all commands for the corresponding DownloaderSyncRequest
+# has been completed (commands are never re-ordered).
+class DownloaderSyncRequest(Command):
+    def action(self):
+        from miro.dl_daemon import download
+        return download.sync_notify()
+
+class DownloaderSyncNotify(Command):
+    def action(self):
+        from miro.messages import DownloaderSyncCommandComplete
+        DownloaderSyncCommandComplete().send_to_frontend()
+
 class BatchUpdateDownloadStatus(Command):
     spammy = True
     def action(self):

--- a/tv/lib/dl_daemon/download.py
+++ b/tv/lib/dl_daemon/download.py
@@ -151,6 +151,9 @@ def stop_upload(dlid):
         _lock.release()
     return download.stop_upload()
 
+def sync_notify():
+    return command.DownloaderSyncNotify(daemon.LAST_DAEMON).send()
+
 def pause_upload(dlid):
     _lock.acquire()
     try:

--- a/tv/lib/downloader.py
+++ b/tv/lib/downloader.py
@@ -72,6 +72,12 @@ def generate_dlid():
         dlid = u"download%08d" % random.randint(0, 99999999)
     return dlid
 
+# NB: sync_downloader_commands: for information on how to use this please
+# see the note in DownloaderSyncRequest/DownloaderSyncNotify.
+def sync_downloader_commands():
+    c = command.DownloaderSyncRequest(RemoteDownloader.dldaemon)
+    c.send()
+
 class RemoteDownloader(DDBObject):
     """Download a file using the downloader daemon."""
     def setup_new(self, url, item, contentType=None, channelName=None):

--- a/tv/lib/frontends/widgets/application.py
+++ b/tv/lib/frontends/widgets/application.py
@@ -1051,6 +1051,27 @@ class Application:
             if path is not None:
                 self.message_handler.profile_next_message(message_obj, path)
 
+    def clog_backend(self):
+        """Dev method: hog the backend to simluate the backend being
+        unresponsive.
+
+        NB: strings not translated on purpose.
+        """
+        title = 'Clog backend'
+        description = ('Make the backend busy by sleeping for a specified '
+                      'number of seconds to simulate a clogged backend.\n\n'
+                      'WARNING: use judiciously!\n\n'
+                      'Default is 0 seconds.')
+        initial_text = '0'
+        n = dialogs.ask_for_string(title, description, initial_text)
+        if n == None:
+            return
+        try:
+            n = int(n)
+        except ValueError:
+            n = 0
+        messages.ClogBackend(n).send_to_backend()
+
     def profile_redraw(self):
         """Devel method: profile time to redraw part of the interface."""
 

--- a/tv/lib/frontends/widgets/application.py
+++ b/tv/lib/frontends/widgets/application.py
@@ -1405,6 +1405,17 @@ class WidgetsMessageHandler(messages.MessageHandler):
         if share.mount:
             messages.SharingEject(share).send_to_backend()
 
+    def handle_downloader_sync_command_comlete(self, message):
+        # This callback is to ensure that if we are in the downloads
+        # resort_on_update is re-enabled.  Walk the display stack to see
+        # if there is a downloading display and if there is, reset the
+        # resort_on_update boolean.
+        displays = app.display_manager.display_stack
+        for d in displays:
+            if d.type == 'downloading':
+                d.controller.item_list.set_resort_on_update(True)
+        logging.debug('DownloadBatchCommandComplete')
+
     def handle_jettison_tabs(self, message):
         typ = message.type
         item_ids = message.ids

--- a/tv/lib/frontends/widgets/itemlist.py
+++ b/tv/lib/frontends/widgets/itemlist.py
@@ -456,6 +456,9 @@ class ItemList(object):
         self._sorter = sorter
         self.model.change_sort(sorter.sort_key, sorter.reverse)
 
+    def set_resort_on_update(self, resort):
+        self.resort_on_update = resort
+
     def resort(self):
         self.set_sort(self._sorter)
 

--- a/tv/lib/frontends/widgets/menus.py
+++ b/tv/lib/frontends/widgets/menus.py
@@ -743,7 +743,7 @@ def on_memory_stats():
     app.widgetapp.memory_stats()
 
 @action_handler("ForceFeedparserProcessing")
-def on_memory_stats():
+def on_force_feedparser_processing():
     app.widgetapp.force_feedparser_processing()
 
 def generate_action_groups(menu_structure):

--- a/tv/lib/frontends/widgets/menus.py
+++ b/tv/lib/frontends/widgets/menus.py
@@ -401,6 +401,7 @@ def get_menu():
                 MenuItem(_("Memory Stats"), "MemoryStats"),
                 MenuItem(_("Force Feedparser Processing"),
                     "ForceFeedparserProcessing"),
+                MenuItem(_("Clog Backend"), "ClogBackend")
                 ])
 
         mbar.menuitems.append(dev_menu)
@@ -745,6 +746,10 @@ def on_memory_stats():
 @action_handler("ForceFeedparserProcessing")
 def on_force_feedparser_processing():
     app.widgetapp.force_feedparser_processing()
+
+@action_handler("ClogBackend")
+def on_clog_backend():
+    app.widgetapp.clog_backend()
 
 def generate_action_groups(menu_structure):
     """Takes a menu structure and returns a map of action group name to

--- a/tv/lib/messagehandler.py
+++ b/tv/lib/messagehandler.py
@@ -1941,6 +1941,12 @@ New ids: %s""", playlist_item_ids, message.item_ids)
             fi.genre = item_info.genre
             fi.signal_change()
 
+    def handle_clog_backend(self, message):
+        logging.debug('handle_clog_backend: Backend snoozing for %d seconds.  '
+                      'ZZZZZZ.', message.n)
+        time.sleep(message.n)
+        logging.debug('handle_clog_backend: Backend out of snooze.  Yawn!')
+
     def handle_force_feedparser_processing(self, message):
         # For all our RSS feeds, force an update
         for f in feed.Feed.make_view():

--- a/tv/lib/messagehandler.py
+++ b/tv/lib/messagehandler.py
@@ -1398,6 +1398,7 @@ New ids: %s""", playlist_item_ids, message.item_ids)
                 item_.pause_upload()
             else:
                 item_.pause()
+        downloader.sync_downloader_commands() 
 
     def handle_pause_download(self, message):
         try:
@@ -1406,6 +1407,7 @@ New ids: %s""", playlist_item_ids, message.item_ids)
             logging.warn("PauseDownload: Item not found -- %s", message.id)
         else:
             item_.pause()
+        downloader.sync_downloader_commands()
 
     def handle_resume_all_downloads(self, message):
         """Resumes downloading and uploading items"""
@@ -1414,6 +1416,7 @@ New ids: %s""", playlist_item_ids, message.item_ids)
                 item_.start_upload()
             else:
                 item_.resume()
+        downloader.sync_downloader_commands()
 
     def handle_resume_download(self, message):
         try:

--- a/tv/lib/messages.py
+++ b/tv/lib/messages.py
@@ -894,6 +894,13 @@ class RateItem(BackendMessage):
         self.info = info
         self.rating = rating
 
+class ClogBackend(BackendMessage):
+    """Dev message: intentionally clog the backend for a specified number of 
+    seconds.
+    """
+    def __init__(self, n=0):
+        self.n = n
+
 class ForceFeedparserProcessing(BackendMessage):
     """Force the backend to do a bunch of feedparser updates
     """

--- a/tv/lib/messages.py
+++ b/tv/lib/messages.py
@@ -901,6 +901,13 @@ class ForceFeedparserProcessing(BackendMessage):
 
 # Frontend Messages
 
+class DownloaderSyncCommandComplete(FrontendMessage):
+    """Tell the frontend that the pause/resume all command are complete,
+    so that we only sort once.  This saves time sorting and also prevents
+    UI clog when items are updated and gets sorted one by one.
+    """
+    pass
+
 class JettisonTabs(FrontendMessage):
     """Tell the frontend to remove certain sidebar tabs from its model.  Done
     when selecting multiple items in the sidebar using the add to new folder


### PR DESCRIPTION
```
bz17155: Address part (b) of bz17155.

Items jump around when you click on pause all or resume all or cancel all.
The problem is the commands to the remote downloader for each individual
item is sent individually and the response is also replied to individually
meaning that when the items update they are resorted, so for n
items you have n updates and thus n resorts, making the UI jerky.

It'd be nice to batch all of this stuff up so that it's one single ipc
but it's too hard to fix, so when we use a pause all, resume all or
cancel all, first, disable the resort mechanism on the downloads
controller, then, perform an ipc rendezvous with the downloader when
all the status updates have been sent so we can re-enable the sort.
```

BONUS!

Fix a menu typo and adds a dev method that can help us further simulate backend traffic jams.
