### PR TITLE
Copy all gstreamer DLLs to our dist directory (#18343)

### DIFF
--- a/tv/windows/setup.py
+++ b/tv/windows/setup.py
@@ -474,8 +474,12 @@ class bdist_miro(Command):
         gstreamer_bin_dir = os.path.join(bdist_dir, 'gstreamer_bin')
         # move them there
         self.copy_gstreamer_dlls(gstreamer_bin_dir)
-        # add that directory to the PATH
+        # add that directory to the PATH so py2exe finds DLLs that it needs
         os.environ['PATH'] = ';'.join([gstreamer_bin_dir, os.environ['PATH']])
+        # add the DLLs to data_files as well, since some of them are linked
+        # dynamically
+        self.distribution.data_files.append(
+                ('', iglob(os.path.join(gstreamer_bin_dir, '*.dll'))))
 
     def copy_gstreamer_dlls(self, dest_path):
         """Copy gstreamer DLLs to a directory.


### PR DESCRIPTION
My previous DLL change left out this part and py2exe wasn't finding them
automatically because gstreamer uses a lot of dynamic DLL loading.
