### PR TITLE
17544. eMusic download support

### DIFF
--- a/tv/lib/emusic.py
+++ b/tv/lib/emusic.py
@@ -69,7 +69,7 @@ def _emx_callback(data, unknown):
     if data['content-type'].startswith('text/html'):
         return unknown(data['original-url'])
 
-    _download_emx_files(StringIO(data['body']))
+    _download_emx_files(StringIO.StringIO(data['body']))
 
 def _download_emx_files(file_):
     dom = minidom.parse(file_)

--- a/tv/lib/filetypes.py
+++ b/tv/lib/filetypes.py
@@ -97,6 +97,10 @@ def is_download_mimetype(mimetype):
     return mimetype in ('application/vnd.emusic-emusic_list',
                         'audio/x-amzxml')
 
+def is_download_url(url):
+    from miro import emusic, amazon
+    return emusic.is_emusic_url(url) or amazon.is_amazon_url(url)
+
 def is_allowed_filename(filename):
     """
     Pass a filename to this method and it will return a boolean

--- a/tv/lib/filetypes.py
+++ b/tv/lib/filetypes.py
@@ -74,7 +74,9 @@ MIMETYPES_EXT_MAP = {
     'application/x-magnet':     ['.magnet'],
 
     'audio/x-mpegurl':  ['.m3u'],
-    'audio/x-amzxml': ['.amz']
+    'audio/x-amzxml': ['.amz'],
+
+    'application/vnd.emusic-emusic_list': ['.emx']
 }
 
 EXT_MIMETYPES_MAP = {}
@@ -91,6 +93,10 @@ def is_allowed_mimetype(mimetype):
     """
     return (mimetype in MIMETYPES_EXT_MAP.keys())
 
+def is_download_mimetype(mimetype):
+    return mimetype in ('application/vnd.emusic-emusic_list',
+                        'audio/x-amzxml')
+
 def is_allowed_filename(filename):
     """
     Pass a filename to this method and it will return a boolean
@@ -99,8 +105,7 @@ def is_allowed_filename(filename):
     return (is_video_filename(filename)
             or is_audio_filename(filename)
             or is_torrent_filename(filename)
-            or filename.endswith('.amz')
-            or filename.endswith('.m3u'))
+            or filename.endswith(('.amz', '.m3u', '.emx')))
 
 def is_playable_filename(filename):
     """

--- a/tv/lib/frontends/widgets/browser.py
+++ b/tv/lib/frontends/widgets/browser.py
@@ -272,7 +272,18 @@ class Browser(widgetset.Browser):
                                  metadata).send_to_backend()
             return False
 
-        return True
+        return self.should_load_url(url)
+
+    def should_download_url(self, url, mimetype):
+        if filetypes.is_download_mimetype(mimetype):
+            logging.debug('downloading %s (%s)', url, mimetype)
+            return True
+        return False
+
+    def do_download_finished(self, url):
+        logging.debug('finished downloading %s', url)
+        self.emit('download-started')
+        messages.DownloadURL(url, self.unknown_callback).send_to_backend()
 
 class BrowserNav(widgetset.VBox):
     def __init__(self, guide_info):

--- a/tv/lib/frontends/widgets/browser.py
+++ b/tv/lib/frontends/widgets/browser.py
@@ -274,9 +274,12 @@ class Browser(widgetset.Browser):
 
         return self.should_load_url(url)
 
-    def should_download_url(self, url, mimetype):
-        if filetypes.is_download_mimetype(mimetype):
+    def should_download_url(self, url, mimetype=None):
+        if mimetype and filetypes.is_download_mimetype(mimetype):
             logging.debug('downloading %s (%s)', url, mimetype)
+            return True
+        if filetypes.is_download_url(url):
+            logging.debug('downloading %s' % url)
             return True
         return False
 

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -804,7 +804,8 @@ class ViewStateSchema(DDBObjectSchema):
     def handle_malformed_selection(value):
         return None
 
-VERSION = 162
+VERSION = 163
+
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,
     FeedImplSchema, RSSFeedImplSchema, SavedSearchFeedImplSchema,

--- a/tv/lib/singleclick.py
+++ b/tv/lib/singleclick.py
@@ -40,6 +40,7 @@ from miro.feedparserutil import FeedParserDict
 
 from miro import app
 from miro import amazon
+from miro import emusic
 from miro import dialogs
 from miro import item
 from miro import feed
@@ -244,13 +245,15 @@ def add_download(url, handle_unknown_callback=None, metadata=None):
         else:
             handle_unknown_callback(url)
 
-    if metadata and 'mime_type' in metadata:
+    if metadata and metadata.get('mime_type'):
         # we've already got the mime type, don't do another call
         callback(None, metadata['mime_type'])
     elif is_magnet_uri(url):
         callback(None, 'application/x-magnet')
     elif amazon.is_amazon_url(url):
         amazon.download_file(url, handle_unknown_callback)
+    elif emusic.is_emusic_url(url):
+        emusic.download_file(url, handle_unknown_callback)
     else:
         httpclient.grab_headers(url, callback, errback)
 

--- a/tv/lib/theme.py
+++ b/tv/lib/theme.py
@@ -194,6 +194,7 @@ class ThemeHistory(DDBObject):
              u"%26node%3D2350149011&tag=pcultureorg-20&linkCode=ur2&camp="
              u"1789&creative=9325", u"Amazon Android Store", True),
             (u"http://market.android.com/", u"Google Android Store", True),
+            (u"http://www.kqzyfj.com/click-5294129-10364534", u"eMusic", True)
             ]
 
         if app.debugmode:

--- a/tv/windows/plat/frontends/widgets/XULRunnerBrowser/MiroBrowserEmbed.cpp
+++ b/tv/windows/plat/frontends/widgets/XULRunnerBrowser/MiroBrowserEmbed.cpp
@@ -39,17 +39,25 @@
 #include <Python.h>
 #include "nsCOMPtr.h"
 #include "nsComponentManagerUtils.h"
+#include "nsCWebBrowserPersist.h"
 #include "nsEmbedCID.h"
+#include "nsIChannel.h"
 #include "nsIDOMWindow.h"
 #include "nsIInterfaceRequestorUtils.h"
+#include "nsIIOService.h"
+#include "nsILocalFile.h"
+#include "nsIProperties.h"
 #include "nsISupportsImpl.h"
 #include "nsIWebBrowser.h"
 #include "nsIWebBrowserFocus.h"
+#include "nsIWebBrowserPersist.h"
 #include "nsDocShellCID.h"
 #include "nsIDocShellTreeItem.h"
 #include "nsIWebNavigationInfo.h"
 #include "nsIURI.h"
 #include "nsServiceManagerUtils.h"
+#include "nsNetCID.h"
+#include "nsXPCOMCID.h"
 
 #include "MiroBrowserEmbed.h"
 #include "xulrunnerbrowser.h"
@@ -163,6 +171,29 @@ nsresult MiroBrowserEmbed::loadURI(const char* uri)
     mWebNavigation->LoadURI(PromiseFlatString(mCurrentURI).get(),
             nsIWebNavigation::LOAD_FLAGS_NONE, 0, 0, 0);
     return NS_OK;
+}
+
+// Download a URI to a path
+nsresult MiroBrowserEmbed::downloadURI(const char* uri, const char* path)
+{
+  nsresult rv;
+  nsIURI *aURI;
+  nsCOMPtr<nsIIOService> io_service(do_GetService(NS_IOSERVICE_CONTRACTID));
+  io_service->NewURI(nsDependentCString(uri), nsnull, nsnull, &aURI);
+  if (!aURI) {
+    return NS_ERROR_FAILURE;
+  }
+  nsCOMPtr<nsIWebBrowserPersist> persist(do_CreateInstance(NS_WEBBROWSERPERSIST_CONTRACTID, &rv));
+  NS_ENSURE_SUCCESS(rv, rv);
+  nsCOMPtr<nsILocalFile> file(do_CreateInstance(NS_LOCAL_FILE_CONTRACTID, &rv));
+  NS_ENSURE_SUCCESS(rv, rv);
+  file->InitWithPath(NS_ConvertASCIItoUTF16(path));
+  persist->SetProgressListener(this);
+  persist->SetPersistFlags(nsIWebBrowserPersist::PERSIST_FLAGS_AUTODETECT_APPLY_CONVERSION|
+			   nsIWebBrowserPersist::PERSIST_FLAGS_CLEANUP_ON_FAILURE|
+			   nsIWebBrowserPersist::PERSIST_FLAGS_FORCE_ALLOW_COOKIES);
+  persist->SaveURI(aURI, nsnull, nsnull, nsnull, "", file);
+  return NS_OK;
 }
 
 nsresult MiroBrowserEmbed::getCurrentURI(char ** uri)
@@ -474,6 +505,7 @@ NS_IMETHODIMP MiroBrowserEmbed::GetSiteWindow(void * *aSiteWindow)
 NS_IMETHODIMP MiroBrowserEmbed::OnStartURIOpen(nsIURI *aURI, PRBool *_retval)
 {
     nsresult rv;
+    int should_load;
     nsCAutoString specString;
     *_retval = PR_FALSE;
 
@@ -484,9 +516,10 @@ NS_IMETHODIMP MiroBrowserEmbed::OnStartURIOpen(nsIURI *aURI, PRBool *_retval)
     // continue the load.  However, it seems like the opposite is actually the
     // case.
     if(mURICallback && is_enabled()) {
-        if(mURICallback((char*)specString.get(), mURICallbackData) == 0) {
-            *_retval = PR_TRUE;
-        }
+      should_load = mURICallback((char*)specString.get(), mURICallbackData);
+      if(should_load == 0) {
+	*_retval = PR_TRUE;
+      }
     }
     return NS_OK;
 }
@@ -556,12 +589,22 @@ NS_IMETHODIMP MiroBrowserEmbed::SetParentContentListener(nsIURIContentListener *
 /* void onStateChange (in nsIWebProgress aWebProgress, in nsIRequest aRequest, in unsigned long aStateFlags, in nsresult aStatus); */
 NS_IMETHODIMP MiroBrowserEmbed::OnStateChange(nsIWebProgress *aWebProgress, nsIRequest *aRequest, PRUint32 aStateFlags, nsresult aStatus)
 {
+    nsresult rv;
+    nsCAutoString specString;
     if((aStateFlags & nsIWebProgressListener::STATE_IS_NETWORK) &&
             mNetworkCallback && is_enabled()) {
+        if (aRequest) {
+	  nsIURI *aURI;
+	  ((nsIChannel*)aRequest)->GetOriginalURI(&aURI);
+          rv = aURI->GetSpec(specString);
+          NS_ENSURE_SUCCESS(rv, rv);
+	} else {
+          NS_NAMED_LITERAL_STRING(specString, "");
+        }
         if(aStateFlags & nsIWebProgressListener::STATE_START) {
-            mNetworkCallback(PR_TRUE, mNetworkCallbackData);
+	  mNetworkCallback(PR_TRUE, (char*)specString.get(), mNetworkCallbackData);
         } else if(aStateFlags & nsIWebProgressListener::STATE_STOP) {
-            mNetworkCallback(PR_FALSE, mNetworkCallbackData);
+	  mNetworkCallback(PR_FALSE, (char*)specString.get(), mNetworkCallbackData);
         }
     }
     return NS_OK;

--- a/tv/windows/plat/frontends/widgets/XULRunnerBrowser/MiroBrowserEmbed.h
+++ b/tv/windows/plat/frontends/widgets/XULRunnerBrowser/MiroBrowserEmbed.h
@@ -58,7 +58,7 @@
 
 typedef void(*focusCallback)(PRBool forward, void* data);
 typedef int(*uriCallback)(char* uri, void* data);
-typedef void(*networkCallback)(PRBool is_start, void* data);
+typedef void(*networkCallback)(PRBool is_start, char* uri, void* data);
 
 class MiroBrowserEmbed   : public nsIWebBrowserChrome,
                            public nsIWebBrowserChromeFocus,
@@ -101,6 +101,8 @@ public:
     nsresult enable();
     // Load a URI into the browser
     nsresult loadURI(const char* uri);
+    // Downloads a URI
+    nsresult downloadURI(const char* uri, const char* path);
     // Gets the current uri from mWebNavigator
     nsresult getCurrentURI(char ** uri);
     // Gets the current title from a long chain of things.  aTitle is a utf-16

--- a/tv/windows/plat/frontends/widgets/XULRunnerBrowser/xulrunnerbrowser.pyx
+++ b/tv/windows/plat/frontends/widgets/XULRunnerBrowser/xulrunnerbrowser.pyx
@@ -38,6 +38,7 @@ cdef extern from "Python.h":
     PyObject* PyObject_CallMethod(PyObject *o, char* name, char* format, ...)
     PyObject* PyObject_CallFunction(PyObject *o, char* format, ...)
     int PyObject_IsTrue(PyObject *o)
+    long PyInt_AsLong(PyObject *o)
     void Py_DECREF(PyObject*)
     void Py_INCREF(PyObject*)
     object PyString_FromString(char *)
@@ -52,7 +53,7 @@ cdef extern from "nscore.h":
 cdef extern from "MiroBrowserEmbed.h":
     ctypedef void(*focusCallback)(PRBool forward, void* data)
     ctypedef int(*uriCallback)(char* data, void* data)
-    ctypedef void(*networkCallback)(PRBool is_start, void* data)
+    ctypedef void(*networkCallback)(PRBool is_start, char* data, void* data)
     ctypedef struct MiroBrowserEmbed:
         nsresult (*init)(unsigned long parentWindow, int x, int y, int width, 
                 int height)
@@ -60,6 +61,7 @@ cdef extern from "MiroBrowserEmbed.h":
         nsresult (*enable)()
         nsresult (*destroy)()
         nsresult (*loadURI)(char* uri)
+        nsresult (*downloadURI)(char* uri, char* path)
         nsresult (*getCurrentURI)(char ** uri)
         nsresult (*getCurrentTitle)(char ** title, int* length)
         nsresult (*resize)(int x, int y, int width, int height)
@@ -183,17 +185,17 @@ cdef int uriCallbackGlue(char *uri, void* data) with gil:
     should_load = PyObject_CallMethod(<PyObject*>data,
             "on_uri_load", "s", uri)
     if should_load:
-        retval = PyObject_IsTrue(should_load)
+        retval = PyInt_AsLong(should_load);
         Py_DECREF(should_load)
     return retval
 
-cdef void networkCallbackGlue(PRBool is_start, void* data) with gil:
+cdef void networkCallbackGlue(PRBool is_start, char* uri, void* data) with gil:
     cdef PyObject* retval
 
     if is_start:
-        retval = PyObject_CallMethod(<PyObject*>data, "on_net_start", "")
+        retval = PyObject_CallMethod(<PyObject*>data, "on_net_start", "s", uri)
     else:
-        retval = PyObject_CallMethod(<PyObject*>data, "on_net_stop", "")
+        retval = PyObject_CallMethod(<PyObject*>data, "on_net_stop", "s", uri)
     if retval:
         Py_DECREF(retval)
 
@@ -250,6 +252,11 @@ cdef class XULRunnerBrowser:
         cdef nsresult rv
         rv = self.browser.loadURI(uri)
         self._check_result('MiroBrowserEmbed.loadURI', rv)
+
+    def download_uri(self, uri, path):
+        cdef nsresult rv
+        rv = self.browser.downloadURI(uri, path)
+        self._check_result('MiroBrowserEmbed.downloadURI', rv)
 
     def get_current_uri(self):
         cdef nsresult rv


### PR DESCRIPTION
eMusic's .emx files can't be downloaded without various cookies, that we can't necessarily get out of the browser.  Instead, we ask the browser to download the file, and then pass it into Miro.
