### PR TITLE
bz17155: Implement batch updates.

### DIFF
--- a/tv/lib/app.py
+++ b/tv/lib/app.py
@@ -74,6 +74,9 @@ backend_config_watcher = None
 frontend_config_watcher = None
 downloader_config_watcher = None
 
+# download state manager
+download_state_manager = None
+
 # sends MetadataProgressUpdate messages to the frontend
 metadata_progress_updater = None
 

--- a/tv/lib/controller.py
+++ b/tv/lib/controller.py
@@ -69,7 +69,9 @@ class Controller:
         logging.info("Shutting down video conversions manager")
         conversions.conversion_manager.shutdown()
         logging.info("Shutting down Downloader...")
-        downloader.shutdown_downloader(self.downloader_shutdown)
+        if app.download_state_manager is not None:
+            app.download_state_manager.shutdown_downloader(
+                self.downloader_shutdown)
         try:
             logging.info("Shutting down worker process.")
             workerprocess.shutdown()

--- a/tv/lib/frontends/widgets/application.py
+++ b/tv/lib/frontends/widgets/application.py
@@ -1424,7 +1424,7 @@ class WidgetsMessageHandler(messages.MessageHandler):
         if share.mount:
             messages.SharingEject(share).send_to_backend()
 
-    def handle_downloader_sync_command_comlete(self, message):
+    def handle_downloader_sync_command_complete(self, message):
         # This callback is to ensure that if we are in the downloads
         # resort_on_update is re-enabled.  Walk the display stack to see
         # if there is a downloading display and if there is, reset the
@@ -1433,7 +1433,7 @@ class WidgetsMessageHandler(messages.MessageHandler):
         for d in displays:
             if d.type == 'downloading':
                 d.controller.item_list.set_resort_on_update(True)
-        logging.debug('DownloadBatchCommandComplete')
+        logging.debug('DownloaderSyncCommandComplete')
 
     def handle_jettison_tabs(self, message):
         typ = message.type

--- a/tv/lib/frontends/widgets/downloadscontroller.py
+++ b/tv/lib/frontends/widgets/downloadscontroller.py
@@ -36,6 +36,7 @@ from miro.frontends.widgets.itemlistwidgets import (
 from miro.frontends.widgets import itemcontextmenu
 from miro.frontends.widgets import prefpanel
 
+from miro import app
 from miro import messages
 from miro import downloader
 from miro import prefs
@@ -90,7 +91,10 @@ class DownloadsController(itemlistcontroller.ItemListController):
     #
     # When complete, the backend is expected to send a reply indicating that
     # all operations (up to this point) are complete and at that point we can
-    # re-enable the sort again.  See DownloadBatchCommandComplete.
+    # re-enable the sort again.  See DownloadSyncCommandComplete().  We hope
+    # for the best that the remote command to do whatever's needed should not
+    # take more than a second or two which should be accurate for a moderately
+    # sized download list.
     def _on_pause_all(self, widget):
         self.item_list.set_resort_on_update(False)
         messages.PauseAllDownloads().send_to_backend()
@@ -111,4 +115,5 @@ class DownloadsController(itemlistcontroller.ItemListController):
 
     def on_items_changed(self):
         self.status_toolbar.update_rates(
-            downloader.total_down_rate, downloader.total_up_rate)
+            app.download_state_manager.total_down_rate,
+            app.download_state_manager.total_up_rate)

--- a/tv/lib/messagehandler.py
+++ b/tv/lib/messagehandler.py
@@ -1393,12 +1393,12 @@ New ids: %s""", playlist_item_ids, message.item_ids)
 
     def handle_pause_all_downloads(self, message):
         """Pauses all downloading and uploading items"""
+        app.download_state_manager.set_bulk_mode()
         for item_ in item.Item.downloading_view():
             if item_.is_uploading():
                 item_.pause_upload()
             else:
                 item_.pause()
-        downloader.sync_downloader_commands() 
 
     def handle_pause_download(self, message):
         try:
@@ -1407,16 +1407,15 @@ New ids: %s""", playlist_item_ids, message.item_ids)
             logging.warn("PauseDownload: Item not found -- %s", message.id)
         else:
             item_.pause()
-        downloader.sync_downloader_commands()
 
     def handle_resume_all_downloads(self, message):
         """Resumes downloading and uploading items"""
+        app.download_state_manager.set_bulk_mode()
         for item_ in item.Item.paused_view():
             if item_.is_uploading_paused():
                 item_.start_upload()
             else:
                 item_.resume()
-        downloader.sync_downloader_commands()
 
     def handle_resume_download(self, message):
         try:
@@ -1427,6 +1426,7 @@ New ids: %s""", playlist_item_ids, message.item_ids)
             item_.resume()
 
     def handle_cancel_all_downloads(self, message):
+        app.download_state_manager.set_bulk_mode()
         for item_ in item.Item.download_tab_view():
             if item_.is_uploading() or item_.is_uploading_paused():
                 item_.stop_upload()

--- a/tv/lib/messages.py
+++ b/tv/lib/messages.py
@@ -907,7 +907,6 @@ class ForceFeedparserProcessing(BackendMessage):
     pass
 
 # Frontend Messages
-
 class DownloaderSyncCommandComplete(FrontendMessage):
     """Tell the frontend that the pause/resume all command are complete,
     so that we only sort once.  This saves time sorting and also prevents

--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -322,7 +322,9 @@ def finish_startup(obj, thread):
     setup_theme()
     install_message_handler()
     itemsource.setup_handlers()
-    downloader.init_controller()
+
+    app.download_state_manager = downloader.DownloadStateManager()
+    app.download_state_manager.init_controller()
 
     # Call this late, after the message handlers have been installed.
     app.sharing_tracker = sharing.SharingTracker()
@@ -423,7 +425,7 @@ def on_frontend_started():
     autoupdate.check_for_updates()
     yield None
     # Delay running high CPU/IO operations for a bit
-    eventloop.add_timeout(5, downloader.startup_downloader,
+    eventloop.add_timeout(5, app.download_state_manager.startup_downloader,
             "start downloader daemon")
     eventloop.add_timeout(10, workerprocess.startup,
             "start worker process")

--- a/tv/lib/test/downloadertest.py
+++ b/tv/lib/test/downloadertest.py
@@ -21,14 +21,15 @@ class DownloaderTest(EventLoopTest):
         app.config.set(prefs.MOVIES_DIRECTORY, self.movies_dir)
 
         # initialize and start the downloader after fixing the MOVIES_DIRECTORY
-        downloader.init_controller()
-        downloader.startup_downloader()
+        # no need to create DownloadStateManager() object.  Aleady created.
+        app.download_state_manager.init_controller()
+        app.download_state_manager.startup_downloader()
 
     def tearDown(self):
-        downloader.shutdown_downloader(
+        app.download_state_manager.shutdown_downloader(
                 lambda: self.stopEventLoop(abnormal=False))
         self.runEventLoop()
-        downloader.daemon_starter = None
+        app.download_state_manager.daemon_starter = None
         EventLoopTest.tearDown(self)
 
     def run_eventloop_until_items(self):

--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -304,6 +304,10 @@ class MiroTestCase(unittest.TestCase):
         # app.extension_manager.load_extension()
         app.extension_manager = extensionmanager.ExtensionManager(
                 [self.tempdir], [])
+        # Create a download state object (but don't start the downloader
+        # for the individual test unless necessary.  In this case we override
+        # the class to run the downloader).
+        app.download_state_manager = downloader.DownloadStateManager()
 
     def set_temp_support_directory(self):
         self.sandbox_support_directory = os.path.join(self.tempdir, 'support')


### PR DESCRIPTION
- Move download information and other related functions into class
  called DownloadStateManager.
- Rate limit the download status updates should they fire in succession.
- Defer download status updates in all cases, and add in appropriate
  state management to deal with it.  Much of it is in update_status()
  in the RemoteDownloader class.  The batch send functionality is
  in DownloadStateManager.
- Make sure that on startup, the restore commands always get sent before
  anything else.

Batching stuff is always "interesting", I think I got all bases covered though.
