### PR TITLE
bz18384: Don't prematurely bail in the transcode sink.

### DIFF
--- a/tv/lib/transcode.py
+++ b/tv/lib/transcode.py
@@ -492,8 +492,6 @@ class TranscodeObject(object):
             try:
                 r, w, x = select.select([self.sink.fileno()], [], [])
                 self.chunk_throttle.wait()
-                if self.segmenter_handle.poll() is not None:
-                    return
                 try:
                     self.sink.handle_request()
                 except socket.error, (err, errstring):


### PR DESCRIPTION
The transcode sink is meant to receive the segmented, transcoded data.
We bailed early when we detected the segmenter's quit, but it could
be the case that there is still some residual data to be received
even after segmenter's determined to have quit.

So, don't bail early.
