### PR TITLE
bz18385: Always invoke trancode cleanup handler.

### DIFF
--- a/tv/lib/libdaap/libdaap.py
+++ b/tv/lib/libdaap/libdaap.py
@@ -201,8 +201,6 @@ class DaapTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
                 del self.activeconn[s]
             except KeyError:
                 pass
-        if self.finished_callback:
-            self.finished_callback(s)
 
 class DaapHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     protocol_version = 'HTTP/1.1'

--- a/tv/lib/sharing.py
+++ b/tv/lib/sharing.py
@@ -1944,7 +1944,6 @@ class SharingManager(object):
             self.disable_discover()
             app.sharing_tracker.pause()
             self.server.set_name(name)
-            self.server.set_finished_callback(self.finished_callback)
 
         if discoverable != self.discoverable:
             if discoverable:
@@ -2083,6 +2082,7 @@ class SharingManager(object):
             self.sharing = False
             return
 
+        self.server.set_finished_callback(self.finished_callback)
         self.server.set_log_message_callback(
             lambda format, *args: logging.info(format, *args))
 


### PR DESCRIPTION
Always invoke transcode cleanup handler.  It wasn't being properly registered
with libdaap.

Also, make sure that in the transcode cleanup handler, all the cleanup
actions are separable by wrapping them individually in try...except blocks
to avoid bailing early on cleanup should one of the statements fail for some
reason.
