### PR TITLE
Unittest fixes.

### DIFF
--- a/tv/lib/test/storedatabasetest.py
+++ b/tv/lib/test/storedatabasetest.py
@@ -584,7 +584,7 @@ class CorruptDDBObjectReprTest(StoreDatabaseTest):
         self.tab_order = tabs.TabOrder(u'channel')
         self.guide = guide.ChannelGuide(u'http://example.com/')
         self.theme_hist = theme.ThemeHistory()
-        self.display_state = widgetstate.DisplayState((u'testtype', u'testid'))
+        self.view_state = widgetstate.ViewState((u'testtype', u'testid', 0))
 
     def check_fixed_value(self, obj, column_name, value, disk_value=None):
         obj = self.reload_object(obj)
@@ -641,17 +641,12 @@ class CorruptDDBObjectReprTest(StoreDatabaseTest):
                               (self.theme_hist.id,))
         self.check_fixed_value(self.theme_hist, 'pastThemes', [])
 
-    def test_corrupt_display_state(self):
-        app.db.cursor.execute("UPDATE display_state SET "
-                "active_filters=?, selected_view=?, "
-                "list_view_columns=?, list_view_widths=? WHERE id=?",
-                ('all', 1, '{baddata', '{baddata', self.display_state.id))
-        self.check_fixed_value(self.display_state, 'list_view_columns', None)
-        self.check_fixed_value(self.display_state, 'list_view_widths', None)
-        # check that fields with valid values were salvaged
-        reloaded = self.reload_object(self.display_state)
-        self.assertEquals(reloaded.active_filters, set([u'all']))
-        self.assertEquals(reloaded.selected_view, 1)
+    def test_corrupt_view_state(self):
+        app.db.cursor.execute("UPDATE view_state SET "
+                "columns_enabled=?, column_widths=? WHERE id=?",
+                ('{baddata', '{baddata', self.view_state.id))
+        self.check_fixed_value(self.view_state, 'columns_enabled', None)
+        self.check_fixed_value(self.view_state, 'column_widths', None)
 
     def test_corrupt_link_history(self):
         # TODO: should test ScraperFeedIpml.linkHistory, but it's not so easy

--- a/tv/lib/test/widgetstateconstantstest.py
+++ b/tv/lib/test/widgetstateconstantstest.py
@@ -6,24 +6,39 @@ class WidgetStateConstants(MiroTestCase):
     def setUp(self):
         MiroTestCase.setUp(self)
         self.display_types = set(WidgetStateStore.get_display_types())
-        self.columns = set()
-        for display_type in self.display_types:
-            self.columns.update(WidgetStateStore.get_columns_available(display_type))
 
     def test_view_types(self):
-        self.assertNotEqual(WidgetStateStore.get_list_view_type(),
-                            WidgetStateStore.get_standard_view_type())
+        # test that all view types are different
+        view_types = (WidgetStateStore.get_list_view_type(),
+                WidgetStateStore.get_standard_view_type(),
+                WidgetStateStore.get_album_view_type())
+
+        for i in range(len(view_types)):
+            for j in range(i + 1, len(view_types)):
+                self.assertNotEqual(view_types[i], view_types[j])
 
     def test_default_view_types(self):
         display_types = set(WidgetStateStore.DEFAULT_VIEW_TYPE)
         self.assertEqual(self.display_types, display_types)
 
     def test_default_column_widths(self):
-        columns = set(WidgetStateStore.DEFAULT_COLUMN_WIDTHS.keys())
-        # MultiRowAlbum is only available in Album View and we manually add it
-        # there.
-        columns.remove("multi-row-album")
-        self.assertEqual(self.columns, columns)
+        # test that all available columns have widths set for them
+
+        # calculate all columns that available for some display/view
+        # combination
+        available_columns = set()
+        display_id = None # this isn't used yet, just set it to a dummy value
+        for display_type in self.display_types:
+            for view_type in (WidgetStateStore.get_list_view_type(),
+                            WidgetStateStore.get_standard_view_type(),
+                            WidgetStateStore.get_album_view_type()):
+                available_columns.update(
+                        WidgetStateStore.get_columns_available(
+                            display_type, display_id, view_type))
+
+        # make sure that we have widths for those columns
+        self.assertEqual(available_columns,
+                set(WidgetStateStore.DEFAULT_COLUMN_WIDTHS.keys()))
 
     def test_default_sort_column(self):
         display_types = set(WidgetStateStore.DEFAULT_SORT_COLUMN)


### PR DESCRIPTION
Fixed test_default_column_widths() after I changed the signature to
get_columns_available().  Changed test_corrupt_display_state() to
test_corrupt_view_state() now that we've moved the columns to the view state
table.

Made test_view_types() test all 3 view type combinations.
