### PR TITLE
bz18413: Check display has type before using.

### DIFF
--- a/tv/lib/frontends/widgets/application.py
+++ b/tv/lib/frontends/widgets/application.py
@@ -1432,7 +1432,7 @@ class WidgetsMessageHandler(messages.MessageHandler):
         # resort_on_update boolean.
         displays = app.display_manager.display_stack
         for d in displays:
-            if d.type == 'downloading':
+            if hasattr(d, 'type') and d.type == 'downloading':
                 d.controller.item_list.set_resort_on_update(True)
         logging.debug('DownloaderSyncCommandComplete')
 


### PR DESCRIPTION
Use hasattr() to check that display has type before using.  It is not
available for all displays.
