### PR TITLE
bz18166. "expire items" preferences for Podcast sync

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -690,7 +690,7 @@ class DeviceSyncManager(object):
             return 0, 0
         count = size = 0
         for info in items:
-            converter = self.conversion_for_info(info, )
+            converter = self.conversion_for_info(info)
             if converter == 'copy':
                 count += 1
                 size += info.size

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -598,23 +598,25 @@ class DeviceSyncManager(object):
             finally:
                 source.unlink()
 
-        for file_type in (u'audio', u'video'):
-            for info in itemsource.DeviceItemSource(self.device,
-                                                    file_type).fetch_all():
-                if (info.feed_url and info.file_url and
-                    info.feed_url in url_to_view):
-                    view = url_to_view[info.feed_url]
-                    new_view = database.View(
-                        view.fetcher,
-                        view.where + (' AND (rd.origURL=? OR rd.url=? '
-                                      'OR item.url=?)'),
-                        view.values + (info.file_url, info.file_url,
-                                       info.file_url),
-                        view.order_by,
-                        view.joins,
-                        view.limit)
-                    if not new_view.count():
-                        expired.add(info)
+        # check for expired items
+        if sync[u'podcasts'].get(u'expire', True):
+            for file_type in (u'audio', u'video'):
+                for info in itemsource.DeviceItemSource(self.device,
+                                                        file_type).fetch_all():
+                    if (info.feed_url and info.file_url and
+                        info.feed_url in url_to_view):
+                        view = url_to_view[info.feed_url]
+                        new_view = database.View(
+                            view.fetcher,
+                            view.where + (' AND (rd.origURL=? OR rd.url=? '
+                                          'OR item.url=?)'),
+                            view.values + (info.file_url, info.file_url,
+                                           info.file_url),
+                            view.order_by,
+                            view.joins,
+                            view.limit)
+                        if not new_view.count():
+                            expired.add(info)
         return infos, expired
 
     def get_auto_items(self, size):

--- a/tv/lib/fileutil.py
+++ b/tv/lib/fileutil.py
@@ -123,8 +123,12 @@ def abspath(path):
     return path
 
 def copy_with_progress(input_path, output_path, block_size=32*1024):
+    flags = os.O_WRONLY | os.O_CREAT
+    if hasattr(os, 'O_SYNC'):
+        flags |= os.O_SYNC
+    output_fd = os.open(output_path, flags)
     with file(input_path, 'rb') as input:
-        with file(output_path, 'wb') as output:
+        with os.fdopen(output_fd, 'wb') as output:
             data = input.read(block_size)
             while data:
                 output.write(data)


### PR DESCRIPTION
Adds a setting which lets users decide /not/ to remove expired podcasts from their device.
