### PR TITLE
bz18416: Fix race with start new download, pause, then resume.

### DIFF
--- a/tv/lib/dl_daemon/command.py
+++ b/tv/lib/dl_daemon/command.py
@@ -184,9 +184,6 @@ class DownloaderBatchCommand(Command):
     PAUSE   = 2
     RESTORE = 4
 
-    RESUME_EXISTING = 0
-    RESUME_NEW      = 1
-
     def action(self):
         from miro.dl_daemon import download
         mark_reply = True
@@ -204,17 +201,10 @@ class DownloaderBatchCommand(Command):
                 else:
                     download.stop_download(dlid, args['delete'])
             elif cmd == self.RESUME:
-                subcmd = args['subcmd']
-                if subcmd == self.RESUME_EXISTING:
-                    download.start_download(dlid)
-                elif cmd == self.RESUME_NEW:
-                    channel_name = args['channel_name']
-                    url = args['url']
-                    content_type = args['content_type']
-                    download.start_new_download(url, dlid, content_type,
-                                                channel_name)
-                else:
-                    raise ValueError('Invalid resume subcommand')
+                channel_name = args['channel_name']
+                url = args['url']
+                content_type = args['content_type']
+                download.start_download(url, dlid, content_type, channel_name)
             elif cmd == self.RESTORE:
                 # Restoring a downloader doesn't actually change any state
                 # so don't reply.

--- a/tv/lib/dl_daemon/download.py
+++ b/tv/lib/dl_daemon/download.py
@@ -81,17 +81,6 @@ def create_downloader(url, content_type, dlid, magnet=None):
     else:
         return HTTPDownloader(url, dlid, expectedContentType=content_type)
 
-def start_new_download(url, dlid, content_type, channel_name):
-    """Creates a new downloader object.
-    """
-    check_u(url)
-    check_u(content_type)
-    if channel_name:
-        check_f(channel_name)
-    dl = create_downloader(url, content_type, dlid)
-    dl.channelName = channel_name
-    _downloads[dlid] = dl
-
 def pause_download(dlid):
     """Pauses a download by download id.
 
@@ -113,16 +102,19 @@ def info_hash_to_long(info_hash):
     """
     return long(str(info_hash), 16)
 
-def start_download(dlid):
+def start_download(url, dlid, content_type, channel_name):
     try:
         download = _downloads[dlid]
+        download.start()
     except KeyError:
-        # There is no download with this id
-        err = u"in start_download(): no downloader with id %s" % dlid
-        c = command.DownloaderErrorCommand(daemon.LAST_DAEMON, err)
-        c.send()
-        return True
-    return download.start()
+        # There is no download with this id.  This is a new download.
+        check_u(url)
+        check_u(content_type)
+        if channel_name:
+            check_f(channel_name)
+        dl = create_downloader(url, content_type, dlid)
+        dl.channelName = channel_name
+        _downloads[dlid] = dl
 
 def stop_download(dlid, delete):
     _lock.acquire()

--- a/tv/lib/downloader.py
+++ b/tv/lib/downloader.py
@@ -71,9 +71,6 @@ class DownloadStateManager(object):
     PAUSE   = command.DownloaderBatchCommand.PAUSE
     RESTORE = command.DownloaderBatchCommand.RESTORE
 
-    RESUME_EXISTING = command.DownloaderBatchCommand.RESUME_EXISTING
-    RESUME_NEW      = command.DownloaderBatchCommand.RESUME_NEW
-
     UPDATE_INTERVAL = 1
 
     def __init__(self):
@@ -543,8 +540,7 @@ class RemoteDownloader(DDBObject):
             self.url = url
             logging.debug("downloading url %s", self.url)
             args = dict(url=self.url, content_type=self.contentType,
-                        channel_name=self.channelName,
-                        subcmd=app.download_state_manager.RESUME_NEW)
+                        channel_name=self.channelName)
             app.download_state_manager.add_download(self.dlid, self)
             app.download_state_manager.queue(self.dlid,
                                              app.download_state_manager.RESUME,
@@ -629,7 +625,8 @@ class RemoteDownloader(DDBObject):
             self.signal_change()
         elif self.get_state() in (u'stopped', u'paused', u'offline'):
             if app.download_state_manager.get_download(self.dlid):
-                args = dict(subcmd=app.download_state_manager.RESUME_EXISTING)
+                args = dict(url=self.url, content_type=self.contentType,
+                            channel_name=self.channelName)
                 app.download_state_manager.queue(
                     self.dlid,
                     app.download_state_manager.RESUME,
@@ -940,7 +937,8 @@ class RemoteDownloader(DDBObject):
             return
         self.manualUpload = True
         if app.download_state_manager.get_download(self.dlid):
-            args = dict(subcmd=app.download_state_manager.RESUME_EXISTING)
+            args = dict(url=self.url, content_type=self.contentType,
+                        channel_name=self.channelName)
             app.download_state_manager.queue(self.dlid,
                                              app.download_state_manager.RESUME,
                                              args)


### PR DESCRIPTION
We batch commands to the downloader process nowadays, and an interesting
scenario may occur.  A "resume" can either be a new download, or it
can be from an existing resume and the commands make such a distinction.
In addition, in the list of pending commands, a pause and a resume pair
will cancel each other out.

If we start a new download, pause, then resume, and the new
download command does not propagate to the downloader process then we
pause, the downloader will not be notified of the new download job.
If we then resume, the downloader will assume that we are resuming
from an existing job and bail.  The problem is a pause cannot perfectly
cancel a resume right now because we don't account for whether it is
existing or new.

Fix this by ensuring that there is no distinction for a resume, and
we take care of this distinction in the downloader process by checking
to see whether the download job is tracked or not.  If it is not tracked
we can assume it is a new job.
