### PR TITLE
bz18447: Ignore AttributeError.

### DIFF
--- a/tv/lib/libdaap/libdaap.py
+++ b/tv/lib/libdaap/libdaap.py
@@ -855,6 +855,9 @@ class DaapClient(object):
         # We've been disconnected, or server gave incorrect response?
         except (IOError, ValueError):
             self.disconnect()
+        except AttributeError:
+            logging.debug('AttributeError caught; probably during shutdown. '
+                          'Ignoring.')
 
     # Generic check for http response.  ValueError() on unexpected response.
     def check_reply(self, response, http_code=httplib.OK, callback=None,


### PR DESCRIPTION
This can happen if the modules are in an inconsistent state during shutdown.
Instead of trying to do an orderly pull-down which isn't necessary,
just ignore it.
