### PR TITLE
Fix for killing dbus after running the unittests

### DIFF
--- a/tv/linux/test.sh
+++ b/tv/linux/test.sh
@@ -35,4 +35,8 @@
 
 # this comes from http://www.estamos.de/blog/2009/05/08/running-syncevolution-as-cron-job/
 # env `dbus-launch` sh -c 'trap "kill $DBUS_SESSION_BUS_PID" EXIT; ./run.sh --unittest utiltest > /home/pcf/test_output.txt 1>&2' || true
-env `dbus-launch` bash -c "trap \"kill $DBUS_SESSION_BUS_PID\" EXIT; ./run.sh --unittest $1 $2 $3"
+
+
+eval `dbus-launch --sh-syntax`
+trap "kill $DBUS_SESSION_BUS_PID" EXIT
+./run.sh --unittest $@


### PR DESCRIPTION
I rewrote the script and split things up rather than having one huge line.
I'm not sure what the problem was before, but it was leaving me with an extra
dbus process each time I ran the unittests.  The new version works for me.
