### PR TITLE
bz18422: Index active database objects via (id, table name).

### DIFF
--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -459,8 +459,9 @@ class MiroTestCase(unittest.TestCase):
 
     def reload_object(self, obj):
         # force an object to be reloaded from the databas.
-        del app.db._object_map[obj.id]
-        app.db._ids_loaded.remove(obj.id)
+        key = (obj.id, app.db.table_name(obj.__class__))
+        del app.db._object_map[key]
+        app.db._ids_loaded.remove(key)
         return obj.__class__.get_by_id(obj.id)
 
     def handle_error(self, obj, report):


### PR DESCRIPTION
It seems that in very rare circumstances we have seen database object
ids being duplicated across different tables, though we believe that
to be impossible based on code inspection and we cannot come up
with a viable explanation as to why it may happen.

Indexing also by the table name will solve the issue.

Additionally, put in a check in database object **init** to confirm
that this is only run within the backend thread to ensure gated
sequential access to the database id allocator.

NOTE: I have deliberately kept the function names the same as I think
they still make sense.  And I have also consciously kept the id allocator 
on a global basis for now.
