### PR TITLE
bz18487: Check validity of watched folder feeds before operating.

### DIFF
--- a/tv/lib/feed.py
+++ b/tv/lib/feed.py
@@ -2094,6 +2094,9 @@ class DirectoryScannerImplBase(FeedImpl):
                     "handle directory watcher updates")
 
     def handle_watcher_updates(self):
+        # If we are not longer valid just return
+        if not self.ufeed.id_exists():
+            return
         # find deleted paths that we have items for
         to_remove = []
         for item in self.items:
@@ -2132,13 +2135,16 @@ class DirectoryScannerImplBase(FeedImpl):
         return known_files
 
     def update(self):
+        self.ufeed.confirm_db_thread()
+        if not self.ufeed.id_exists():
+            return
+
         if not self.updating:
             self.updating = True
             self.do_update()
 
     @eventloop.idle_iterator
     def do_update(self):
-        self.ufeed.confirm_db_thread()
 
         def should_halt_early():
             """Check if we should halt before completing the entire update.


### PR DESCRIPTION
There are some delayed calls for watched folders but by the time they
actually run the feeds could be no longer available because maybe
it has been deleted.  In this case make sure we don't aimlessly
contnue, which can lead to ObjectNotFoundError when it fetches
the non-existent watched folder feed.
