### PR TITLE
Don't draw the GTK focus ring in albumview (#18272)

### DIFF
--- a/tv/lib/frontends/widgets/gtk/tableview.py
+++ b/tv/lib/frontends/widgets/gtk/tableview.py
@@ -62,6 +62,20 @@ from miro.frontends.widgets.gtk.tableviewcells import (GTKCustomCellRenderer,
 PathInfo = namedtuple('PathInfo', 'path column x y') 
 Rect = namedtuple('Rect', 'x y width height') 
 
+_album_view_gtkrc_installed = False
+def _install_album_view_gtkrc():
+    """Hack for disabling the focus ring on the album view widget."""
+    global _album_view_gtkrc_installed
+    if _album_view_gtkrc_installed:
+        return
+    rc_string = ('style "album-view-style"\n'
+                 '{ \n'
+                 '  GtkWidget::focus-line-width = 0 \n'
+                 '}\n'
+                 'widget "*.miro-album-view" style "album-view-style"\n')
+    gtk.rc_parse_string(rc_string)
+    _album_view_gtkrc_installed = True
+
 def rect_contains_rect(outside, inside):
     # currently unused
     return (outside.x <= inside.x and
@@ -1208,6 +1222,10 @@ class TableView(Widget, GTKSelectionOwnerMixin, DNDHandlerMixin,
         """
         column_spacing = TableColumn.FIXED_PADDING * len(self.columns)
         return total_width - column_spacing
+
+    def enable_album_view_focus_hack(self):
+        _install_album_view_gtkrc()
+        self._widget.set_name("miro-album-view")
 
     def focus(self):
         self._widget.grab_focus()

--- a/tv/lib/frontends/widgets/itemlistwidgets.py
+++ b/tv/lib/frontends/widgets/itemlistwidgets.py
@@ -1137,6 +1137,7 @@ class AlbumView(ListView):
         ListView.__init__(self, item_list, renderer_set, sorts, column_widths)
         self.set_group_lines_enabled(True)
         self.set_group_line_style(widgetutil.css_to_color('#dddddd'), 1)
+        self.enable_album_view_focus_hack()
 
 class DownloadStatusToolbar(Toolbar):
     """Widget that shows free space and download and upload speed

--- a/tv/osx/plat/frontends/widgets/tableview.py
+++ b/tv/osx/plat/frontends/widgets/tableview.py
@@ -1257,6 +1257,10 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         self.header_view.custom_header = True
         self.tableview.setCornerView_(SorterPadding.alloc().init())
 
+    def enable_album_view_focus_hack(self):
+        # this only matters on GTK
+        pass
+
     def focus(self):
         if self.tableview.window() is not None:
             self.tableview.window().makeFirstResponder_(self.tableview)


### PR DESCRIPTION
The issue is that the focus ring gets drawn over the hybrid column, which
messes things up substantially.  I tried to fix this, but I think the best way
is to just disable it entirely.
