### PR TITLE
bz18468. don't crash if the device doesn't have settings

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -547,7 +547,8 @@ class DeviceSyncManager(object):
     def __init__(self, device):
         self.device = device
         self.device_info = self.device.info
-        self.device_settings = self.device.database.get(u'settings')
+        self.device_settings = self.device.database.setdefault(u'settings',
+                                                               {})
         self.start_time = time.time()
         self.signal_handles = []
         self.finished = 0


### PR DESCRIPTION
We tried to be more efficient by caching the device's settings dictionary, but
if it didn't exist we'd crash. Now we setup a default dictionary if there
aren't any existing settings.
