### PR TITLE
bz18429. don't crash if Expat doesn't get any data

### DIFF
--- a/tv/lib/emusic.py
+++ b/tv/lib/emusic.py
@@ -29,6 +29,8 @@
 
 """Functions for downloading from eMusic."""
 
+import logging
+
 from miro import app
 from miro import httpclient
 from miro import fileutil
@@ -74,7 +76,10 @@ def _emx_callback(data, unknown):
 def _download_emx_files(file_):
     try:
         dom = minidom.parse(file_)
-    except Exception:
+    except Exception, e:
+        if e.message == 'no element found: line 1, column 0':
+            logging.debug('got _emx file with no data, skipping')
+            return
         with file(file_, 'rb') as f:
             app.controller.failed_soft('_emx_callback',
                                        'could not parse %r, data:\n%r' % (


### PR DESCRIPTION
We get the following Exception when there's no data in the .emx file:

``````
Traceback (most recent call last):
  File "miro/emusic.pyo", line 76, in _download_emx_files
  File "xml/dom/minidom.pyo", line 1914, in parse
  File "xml/dom/expatbuilder.pyo", line 924, in parse
  File "xml/dom/expatbuilder.pyo", line 211, in parseFile
ExpatError: no element found: line 1, column 0```
``````

We check for that message; if it's there, then we just log that there's no data
and move on.
