### PR TITLE
bz18401. better check for existing connection to signals

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -934,7 +934,7 @@ class DeviceSyncManager(object):
         conversion_manager = conversions.conversion_manager
         start_conversion = conversion_manager.start_conversion
 
-        if not self.waiting:
+        if not self.signal_handles:
             for signal, callback in (
                 ('task-changed', self._conversion_changed_callback),
                 ('task-staged', self._conversion_staged_callback),


### PR DESCRIPTION
It appears that `self.waiting` can become empty and have `start_conversion()`
called again.  Instead of checking that, just check if we're currently
connected to the signals.
