### PR TITLE
bz18453. Vimeo videos are not always downloaded

### DIFF
--- a/tv/lib/flashscraper.py
+++ b/tv/lib/flashscraper.py
@@ -312,7 +312,7 @@ def _scrape_vimeo_callback(info, callback):
     url = info['redirected-url']
     try:
         doc = minidom.parseString(info['body'])
-        id_ = VIMEO_CLIP_RE.match(url).group(1)
+        id_ = VIMEO_CLIP_RE.match(url).group('id_')
         req_sig = doc.getElementsByTagName('request_signature').item(0).firstChild.data.decode('ascii', 'replace')
         req_sig_expires = doc.getElementsByTagName('request_signature_expires').item(0).firstChild.data.decode('ascii', 'replace')
         url = (u"http://www.vimeo.com/moogaloop/play/clip:%s/%s/%s/?q=" %


### PR DESCRIPTION
With some Vimeo URLs, our regex wasn't getting the Vimeo video ID.  Since the
group was named before, we switch to getting the named group all the time,
instead of the the numbered one.
