### PR TITLE
Fix to run gst_extractor correctly on linux.

### DIFF
--- a/tv/linux/plat/renderers/__init__.py
+++ b/tv/linux/plat/renderers/__init__.py
@@ -55,7 +55,6 @@ def set_renderer(modname):
         pkg = __import__('miro.plat.renderers.' + modname)
         module = getattr(pkg.plat.renderers, modname)
         app.audio_renderer, app.video_renderer = module.make_renderers()
-        app.run_media_metadata_extractor = module.run_extractor
         app.get_item_type = module.get_item_type
         logging.info("set_renderer: successfully loaded %s", modname)
     except StandardError:

--- a/tv/linux/plat/renderers/gstreamerrenderer.py
+++ b/tv/linux/plat/renderers/gstreamerrenderer.py
@@ -44,10 +44,6 @@ from miro.plat import options
 # We need to define get_item_type().  Use the version from sniffer.
 from miro.frontends.widgets.gst.sniffer import get_item_type
 
-def run_extractor(movie_path, thumbnail_path):
-    from miro.plat.renderers import gst_extractor
-    return gst_extractor.run(movie_path, thumbnail_path)
-
 class LinuxSinkFactory(renderer.SinkFactory):
     """Linux class to create gstreamer audio/video sinks.
 

--- a/tv/linux/plat/utils.py
+++ b/tv/linux/plat/utils.py
@@ -313,7 +313,8 @@ def exit_miro(return_code):
     sys.exit(return_code)
 
 def run_media_metadata_extractor(movie_path, thumbnail_path):
-    return app.run_media_metadata_extractor(movie_path, thumbnail_path)
+    from miro.plat.renderers import gst_extractor
+    return gst_extractor.run(movie_path, thumbnail_path)
 
 def miro_helper_program_info():
     """Get the command line to launch miro_helper.py """


### PR DESCRIPTION
We don't have the app module setup in our subprocess module, so we can't use
the previous approach.  That code is pretty weird anyways, since it's trying
to support multiple renderers which is something we don't need anymore.

Implemented a more direct approach, we just put the logic we want in
plat.utils.run_media_metadata_extractor()
