### PR TITLE
Run the incomplete metadata in one go.

### DIFF
--- a/tv/lib/moviedata.py
+++ b/tv/lib/moviedata.py
@@ -176,7 +176,6 @@ class MovieDataUpdater(object):
         if self.in_shutdown:
             return
         if item.id in self.in_progress:
-            logging.warn("Not adding in-progess item (%s)", item.id)
             return
 
         if self._should_process_item(item):


### PR DESCRIPTION
Slurp in anything that does not have complete metadata and hand that
off to the metadata request update.  If it was a duplicate item
the request_update() is smart enough to handle that so we need not
worry about adding duplicates.

Previous implementation was broken because we limited the amount of items
that we got to 100 and if we don't clear those fast enough we end up
re-querying the same items over and over again and adding them and
then failing to do so because it's already been added in a
previous iteration which is not cool.
