### PR TITLE
Don't pack invalid daap properties.

### DIFF
--- a/tv/lib/libdaap/subr.py
+++ b/tv/lib/libdaap/subr.py
@@ -313,7 +313,11 @@ def encode_response(reply, content_encoding=None):
             # order
             fmt = '!4sI' + fmt
             # XXX slow - should bunch up
-            blob += struct.pack(fmt, code, size, value)
+            try:
+                blob += struct.pack(fmt, code, size, value)
+            except struct.error:
+                # This pack did not work.  Let's ignore it
+                pass
             blob += subblob
         blob = StreamObj(blob, content_encoding=content_encoding)
     except ValueError:


### PR DESCRIPTION
Let's not pack invalid daap properties.  If the struct module cannot
convert it into a binary value then just skip over it.

Also better diagnostics for the do_send_reply() function.  If it fails
let's catch it and print and exception before re-raising it for the
upper layers to handle (which normally means disconnection).
