### PR TITLE
bz18511. crash when expiring auto-sync items

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -818,7 +818,6 @@ class DeviceSyncManager(object):
                  if data.get(u'auto_sync', False)]
         for (file_type, id_) in self.yield_items_to_get_to(size, sizes):
             data = self.device.database[file_type].pop(id_)
-            del self.device.database[file_type][id_]
             fileutil.delete(os.path.join(self.device.mount,
                                          utf8_to_filename(
                         id_.encode('utf8'))))


### PR DESCRIPTION
We were removing items from the device database twice; clearly that doesn't
work.
