### PR TITLE
bz18519. crash when syncing multiple items

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -712,8 +712,7 @@ class DeviceSyncManager(object):
             items = items_for_converter.pop('copy')
             count += len(items)
             size += sum(info.size for info in items)
-        for converter in items_for_converter:
-            items = items_for_converter.pop(converter)
+        for converter, items in items_for_converter.items():
             for info in items:
                 task = conversions.conversion_manager._make_conversion_task(
                     converter, info,


### PR DESCRIPTION
We were iterating over the dictionary keys, then popping the values.  Python
doesn't like it when you change the length of a dictionary during iteration, so
just pull the items out along with the name of the converter.
