### PR TITLE
bz18502: Create indices for columns that we use joins on.

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3455,3 +3455,14 @@ def upgrade164(cursor):
     # drop old columns
     remove_column(cursor, 'display_state', ['list_view_columns'])
     remove_column(cursor, 'display_state', ['list_view_widths'])
+
+def upgrade165(cursor):
+    """Add lots of indexes."""
+    indices = [
+      ('playlist_item_map_item_id', 'playlist_item_map', 'item_id'),
+      ('playlist_folder_item_map_item_id', 'playlist_folder_item_map',
+       'item_id'),
+      ('feed_impl_key', 'feed', 'feed_impl_id')
+    ]
+    for n, t, c in indices:
+        cursor.execute("CREATE INDEX %s ON %s (%s)" % (n, t, c))

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -528,6 +528,10 @@ class FeedSchema(DDBObjectSchema):
         ('last_viewed', SchemaDateTime()),
     ]
 
+    indexes = (
+        ('feed_impl_key', ('feed_impl_id',)),
+    )
+
 class FeedImplSchema(DDBObjectSchema):
     klass = FeedImpl
     table_name = 'feed_impl'
@@ -682,6 +686,10 @@ class PlaylistItemMapSchema(DDBObjectSchema):
         ('position', SchemaInt()),
     ]
 
+    indexes = (
+        ('playlist_item_map_item_id', ('item_id',)),
+    )
+
 class PlaylistFolderItemMapSchema(DDBObjectSchema):
     klass = PlaylistFolderItemMap
     table_name = 'playlist_folder_item_map'
@@ -691,6 +699,10 @@ class PlaylistFolderItemMapSchema(DDBObjectSchema):
         ('position', SchemaInt()),
         ('count', SchemaInt()),
     ]
+
+    indexes = (
+        ('playlist_folder_item_map_item_id', ('item_id',)),
+    )
 
 class TabOrderSchema(DDBObjectSchema):
     klass = TabOrder
@@ -805,7 +817,7 @@ class ViewStateSchema(DDBObjectSchema):
         return None
 
 
-VERSION = 164
+VERSION = 165
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,


### PR DESCRIPTION
Using sqlite3 module from Python means we'd better make sure the
JOIN ON columns have indices or else they can get real slow.
