### PR TITLE
bz18526. don't have progress go above 100%

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1147,7 +1147,7 @@ class DeviceSyncManager(object):
         if not total:
             return 0.0
         progress = float(sum(self.progress_size.itervalues()))
-        return progress / total
+        return min(progress / total, 1.0)
 
     def cancel(self):
         if not self.started:


### PR DESCRIPTION
Since we're guessing about the sizes of converted items, we can guess a bit low
and overshoot the guess.  At that point, we're pretty close to 100% anyways, so
just crop the value to 100% and move on.
