### PR TITLE
bz18284: Make sure we don't kill pending manual downloads on restart.

### DIFF
--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -597,6 +597,7 @@ def reconnect_downloaders():
         downloader_.remove()
     manualItems = item.Item.feed_view(feed.Feed.get_manual_feed().get_id())
     for item_ in manualItems:
-        if item_.__class__ == item.Item and not item_.has_downloader():
+        if (item_.__class__ == item.Item and not item_.has_downloader() and
+          not item_.pendingManualDL):
             logging.warn("removing cancelled external torrent: %s", item_)
             item_.remove()


### PR DESCRIPTION
Pending manual downloads do not have a downloader associated with it
and when they are restarted they are culled.  We shouldn't do this if
it was marked pending.
