### PR TITLE
bz18536: Rework subprocess scheme to allow setting gstreamer variables e...

### DIFF
--- a/tv/lib/conversions.py
+++ b/tv/lib/conversions.py
@@ -55,6 +55,7 @@ from miro.gtcache import gettext as _
 from miro.fileobject import FilenameType
 from miro.plat import utils
 from miro.plat import resources
+from miro.plat.popen import Popen
 
 NON_WORD_CHARS = re.compile(r"[^a-zA-Z0-9]+")
 
@@ -878,12 +879,9 @@ class ConversionTask(object):
                   "stdout": subprocess.PIPE,
                   "stderr": subprocess.STDOUT,
                   "stdin": subprocess.PIPE,
-                  "startupinfo": util.no_console_startupinfo()}
-        if os.name != "nt":
-            kwargs["close_fds"] = True
-
+                  "close_fds": True}
         try:
-            self.process_handle = subprocess.Popen(args, **kwargs)
+            self.process_handle = Popen(args, **kwargs)
             self.process_output(line_reader(self.process_handle.stdout))
             self.process_handle.wait()
 

--- a/tv/lib/subprocessmanager.py
+++ b/tv/lib/subprocessmanager.py
@@ -58,6 +58,7 @@ from miro import messagetools
 from miro import trapcall
 from miro import util
 from miro.plat.utils import miro_helper_program_info, initialize_locale
+from miro.plat.popen import Popen
 
 def _on_windows():
     """Test if we are unfortunate enough to be running in windows."""
@@ -348,19 +349,11 @@ class SubprocessManager(object):
         kwargs = {
                   "stdout": subprocess.PIPE,
                   "stdin": subprocess.PIPE,
-                  "startupinfo": util.no_console_startupinfo(),
+                  "stderr": open(os.devnull, 'wb'),
                   "env": env,
+                  "close_fds": True
         }
-        if _on_windows():
-            # normally we just clone stderr for the subprocess, but on windows
-            # this doesn't work.  So we use a pipe that we immediately close
-            kwargs["stderr"] = subprocess.PIPE
-        else:
-            kwargs["stderr"] = None
-            kwargs["close_fds"] = True
-        process = subprocess.Popen(cmd_line, **kwargs)
-        if _on_windows():
-            process.stderr.close()
+        process = Popen(cmd_line, **kwargs)
         return process
 
     def shutdown(self, timeout=1.0):

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -51,6 +51,7 @@ import urllib
 
 from miro.clock import clock
 from miro import filetypes
+from miro.plat.popen import Popen
 
 # Do NOT import libtorrent up here.  libtorrent.so is compiled with
 # @executable_path-relative path dependency for the Python library
@@ -616,23 +617,6 @@ def quote_unicode_url(url):
             quoted_chars.append(c)
     return u''.join(quoted_chars)
 
-def no_console_startupinfo():
-    """Returns the startupinfo argument for subprocess.Popen so that
-    we don't open a console window.  On platforms other than windows,
-    this is just None.  On windows, it's some win32 silliness.
-    """
-    if subprocess.mswindows:
-        startupinfo = subprocess.STARTUPINFO()
-        # XXX temporary: STARTF_USESHOWWINDOW is in a different location
-        # as of Python 2.6.6
-        try:
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        except AttributeError:
-            startupinfo.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
-        return startupinfo
-    else:
-        return None
-
 def call_command(*args, **kwargs):
     """Call an external command.  If the command doesn't exit with
     status 0, or if it outputs to stderr, an exception will be raised.
@@ -652,9 +636,8 @@ def call_command(*args, **kwargs):
     if kwargs:
         raise TypeError('extra keyword arguments: %s' % kwargs)
 
-    pipe = subprocess.Popen(args, stdout=subprocess.PIPE,
-            stdin=subprocess.PIPE, stderr=subprocess.PIPE,
-            startupinfo=no_console_startupinfo())
+    pipe = Popen(args, stdout=subprocess.PIPE,
+                 stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = pipe.communicate()
     if return_everything:
         return (pipe.returncode, stdout, stderr)

--- a/tv/linux/plat/popen.py
+++ b/tv/linux/plat/popen.py
@@ -27,36 +27,10 @@
 # this exception statement from your version. If you delete this exception
 # statement from all source files in the program, then also delete it here.
 
-"""gstreamerrenderer.py -- Windows gstreamer renderer """
+import subprocess
 
-import pygst
-pygst.require('0.10')
-import gst
-
-from miro import app
-from miro.frontends.widgets.gst import renderer
-
-# We need to define get_item_type().  Use the version from sniffer.
-from miro.frontends.widgets.gst.sniffer import get_item_type
-
-class WindowsSinkFactory(renderer.SinkFactory):
-    """Windows class to create gstreamer audio/video sinks.
-
-    This class is very simple because we know exactly what gstreamer plugins
-    we install on windows.
+def Popen(args, **kwargs):
+    """Like subprocess.Popen but make sure we get rid of any platform
+    quirks.  This is a nop on *nix.
     """
-
-    def make_audiosink(self):
-        return gst.element_factory_make("directsoundsink" , "audiosink")
-
-    def make_videosink(self):
-        # Use dshowvideosink.
-        # d3dvideosink doesn't work on my vmware VM.
-        # directdrawsink does work, but I believe it is less likely to be
-        # hardware accelerated than the direct show one.
-        return gst.element_factory_make("dshowvideosink" , "videosink")
-
-def make_renderers():
-    sink_factory = WindowsSinkFactory()
-    return (renderer.AudioRenderer(sink_factory),
-            renderer.VideoRenderer(sink_factory))
+    return subprocess.Popen(args, **kwargs)

--- a/tv/linux/plat/utils.py
+++ b/tv/linux/plat/utils.py
@@ -37,6 +37,7 @@ import logging
 import logging.handlers
 import locale
 import urllib
+import subprocess
 import sys
 import time
 from miro.util import returns_unicode, returns_binary, check_u, check_b

--- a/tv/osx/plat/devicetracker.py
+++ b/tv/osx/plat/devicetracker.py
@@ -36,6 +36,7 @@ from Foundation import *
 from FSEvents import *
 
 from miro import app
+from miro.plat.popen import Popen
 
 kFSEventStreamCreateFlagIgnoreSelf = 0x08 # not defined for some reason
 
@@ -47,8 +48,7 @@ def diskutil(cmd, path_or_disk, use_plist=True):
         args.append('-plist')
     if path_or_disk:
         args.append(path_or_disk)
-    proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    proc = Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = proc.communicate()
     if not use_plist:
         return stdout

--- a/tv/osx/plat/popen.py
+++ b/tv/osx/plat/popen.py
@@ -27,36 +27,10 @@
 # this exception statement from your version. If you delete this exception
 # statement from all source files in the program, then also delete it here.
 
-"""gstreamerrenderer.py -- Windows gstreamer renderer """
+import subprocess
 
-import pygst
-pygst.require('0.10')
-import gst
-
-from miro import app
-from miro.frontends.widgets.gst import renderer
-
-# We need to define get_item_type().  Use the version from sniffer.
-from miro.frontends.widgets.gst.sniffer import get_item_type
-
-class WindowsSinkFactory(renderer.SinkFactory):
-    """Windows class to create gstreamer audio/video sinks.
-
-    This class is very simple because we know exactly what gstreamer plugins
-    we install on windows.
+def Popen(args, **kwargs):
+    """Like subprocess.Popen but make sure we get rid of any platform
+    quirks.  This is a nop on Mac.
     """
-
-    def make_audiosink(self):
-        return gst.element_factory_make("directsoundsink" , "audiosink")
-
-    def make_videosink(self):
-        # Use dshowvideosink.
-        # d3dvideosink doesn't work on my vmware VM.
-        # directdrawsink does work, but I believe it is less likely to be
-        # hardware accelerated than the direct show one.
-        return gst.element_factory_make("dshowvideosink" , "videosink")
-
-def make_renderers():
-    sink_factory = WindowsSinkFactory()
-    return (renderer.AudioRenderer(sink_factory),
-            renderer.VideoRenderer(sink_factory))
+    return subprocess.Popen(args, **kwargs)

--- a/tv/osx/plat/utils.py
+++ b/tv/osx/plat/utils.py
@@ -53,6 +53,7 @@ from miro.plat.filenames import (PlatformFilenameType,
                                  filename_type_to_os_filename)
 from miro.plat import qt_extractor
 from miro.plat.frontends.widgets.threads import on_ui_thread
+from miro.plat.popen import Popen
 
 # We need to define samefile for the portable code.  Lucky for us, this is
 # very easy.
@@ -353,7 +354,7 @@ def _app_command_line():
     if os_version < 9:
         return [exe]
     else:
-        arch = subprocess.Popen("/usr/bin/arch", stdout=subprocess.PIPE).communicate()[0].strip()
+        arch = Popen("/usr/bin/arch", stdout=subprocess.PIPE).communicate()[0].strip()
         return ['/usr/bin/arch', '-%s' % arch, exe]
 
 @on_ui_thread

--- a/tv/windows/Miro.py
+++ b/tv/windows/Miro.py
@@ -30,10 +30,19 @@
 """Startup the main Miro process or run unittests.
 """
 
+import os
 import sys
 import logging
 
 def startup(argv):
+    # Before importing gstreamer, fix os.environ so gstreamer finds its
+    # plugins.  Do this early before any code is run to prevent any import
+    # of gst missing this!
+    from miro.plat import resources
+    GST_PLUGIN_PATH = os.path.join(resources.app_root(), 'gstreamer-0.10')
+    os.environ["GST_PLUGIN_PATH"] = GST_PLUGIN_PATH
+    os.environ["GST_PLUGIN_SYSTEM_PATH"] = GST_PLUGIN_PATH
+
     theme = None
     # Should have code to figure out the theme.
 

--- a/tv/windows/plat/popen.py
+++ b/tv/windows/plat/popen.py
@@ -1,0 +1,90 @@
+# Miro - an RSS based video player application
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011
+# Participatory Culture Foundation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# In addition, as a special exception, the copyright holders give
+# permission to link the code of portions of this program with the OpenSSL
+# library.
+#
+# You must obey the GNU General Public License in all respects for all of
+# the code used other than OpenSSL. If you modify file(s) with this
+# exception, you may extend this exception to your version of the file(s),
+# but you are not obligated to do so. If you do not wish to do so, delete
+# this exception statement from your version. If you delete this exception
+# statement from all source files in the program, then also delete it here.
+
+"""
+Implements a platform specific Popen that hides all the platform
+differences.
+"""
+
+import logging
+import os
+import subprocess
+
+def cleanse_environment(env=None):
+    """Given an environment dictionary, clean it by removing all traces
+    of unicode types, as this is not supported on Windows when passing
+    it via subprocesses.
+    """
+    source = env if env else os.environ.copy()
+    env = source.copy()
+    for k, v in source.iteritems():
+        if isinstance(v, unicode):
+            logging.debug('cleanse environment: %s in unicode with value %r.  '
+                          'Removing.', k, v)
+            del env[k]
+    return env
+
+def Popen(args, **kwargs):
+    """Like subprocess.Popen but make sure we get rid of any platform
+    quirks.  On Windows this means:
+
+    Set STARTF_USESHOWWINDOW flag
+    Clean environment any unicode types
+    Remove close_fds argument (not supported)
+    """
+    startupinfo = subprocess.STARTUPINFO()
+    # XXX temporary: STARTF_USESHOWWINDOW is in a different location
+    # as of Python 2.6.6
+    try:
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    except AttributeError:
+        startupinfo.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
+    kwargs['startupinfo'] = startupinfo
+    try:
+        env = kwargs['env']
+    except KeyError:
+        env = None
+    finally:
+        kwargs['env'] = cleanse_environment(env)
+    try:
+        del kwargs['close_fds']    # not supported on Windows
+    except KeyError:
+        pass
+    # Rules for quoting.
+    # http://docs.python.org/library/subprocess.html
+    # In section: #converting-argument-sequence 17.1.5.1
+    #
+    # In practical terms, it means if we are passing in a string type
+    # then we should follow the quote rules, and if you pass in a
+    # sequence type it should implement correct quoting.
+    # I'm going to declare that this version of Popen only accepts
+    # sequence types for the program argument (though implementing
+    # correcting quoting is probably < 20 lines of code).
+
+    return subprocess.Popen(args, **kwargs)


### PR DESCRIPTION
...arly.

The gstreamer environment variables needs to be set early to prevent
an import prematurely happening and thus missing out on these
variables, and thus not looking up in these paths.

But setting it in the environ is not that easy, because Windows has
certain limitations about what you can and can't set there, among
other limitations.  So rework the code so that these problems are
not present.
