### PR TITLE
bz18548: Robust conversion from input type to string in Edit Metadata.

### DIFF
--- a/tv/lib/frontends/widgets/itemedit.py
+++ b/tv/lib/frontends/widgets/itemedit.py
@@ -262,7 +262,14 @@ class NumberField(Field):
             self.widget.set_width(width)
             self.widget.set_max_length(width)
         value = self.common_value or ""
-        self.widget.set_text(str(value))
+        # Ugh!  Convert to utf-8 or else decode may not work!
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
+        try:
+            value = str(value)
+        except TypeError, ValueError:
+            value = ''
+        self.widget.set_text(value)
 
     def get_value(self):
         value = self.widget.get_text()


### PR DESCRIPTION
Noticed an mp3 where the season number was encoded as a string and so
the edit metadata dialog crashed when I tried to open it up.

Added some conversion fallback safety as well.
