### PR TITLE
bz18285: Don't explicitly call destroy() for GTK widgets.

### DIFF
--- a/tv/lib/frontends/widgets/gtk/persistentwindow.py
+++ b/tv/lib/frontends/widgets/gtk/persistentwindow.py
@@ -55,8 +55,6 @@ def _get_dummy_window():
                 wclass=gtk.gdk.INPUT_OUTPUT, event_mask=0)
     return _dummy_window
 
-_persistent_window_to_widget = weakref.WeakValueDictionary()
-
 class PersistentWindow(gtk.DrawingArea):
     """GTK Widget that keeps around a GDK window from the time it's realized
     to the time it's destroyed.
@@ -71,7 +69,6 @@ class PersistentWindow(gtk.DrawingArea):
         self.persistent_window = gtk.gdk.Window(_get_dummy_window(),
                 x=0, y=0, width=1, height=1, window_type=gtk.gdk.WINDOW_CHILD,
                 wclass=gtk.gdk.INPUT_OUTPUT, event_mask=self.get_events())
-        _persistent_window_to_widget[self.persistent_window] = self
 
     def set_events(self, event_mask):
         gtk.DrawingArea.set_events(self, event_mask)
@@ -108,16 +105,9 @@ class PersistentWindow(gtk.DrawingArea):
         try:
             gtk.DrawingArea.do_destroy(self)
             self.persistent_window.withdraw()
-            self.persistent_window.destroy()
             self.persistent_window = None
         except AttributeError:
             # Probably means we're in shutdown, so our symbols have been
             # deleted
             pass
 gobject.type_register(PersistentWindow)
-
-def get_widgets():
-    retval = []
-    for window in _get_dummy_window().get_children():
-        retval.append(_persistent_window_to_widget[window])
-    return retval

--- a/tv/lib/frontends/widgets/gtk/video.py
+++ b/tv/lib/frontends/widgets/gtk/video.py
@@ -593,7 +593,6 @@ class VideoPlayer(player.GTKPlayer, VBox):
             self.pack_start(self._video_details)
             main_window.main_vbox.pack_start(main_window.controls_hbox)
 
-            self.overlay.destroy()
             self.overlay = None
 
     def rebuild_video_details(self):

--- a/tv/lib/frontends/widgets/gtk/widgets.py
+++ b/tv/lib/frontends/widgets/gtk/widgets.py
@@ -65,7 +65,7 @@ class Window:
         return True
 
     def close(self):
-        self._widget.destroy()
+        self._widget = None
 
     def set_content_widget(self, widget):
         """Set the widget that will be drawn in the content area for this

--- a/tv/lib/frontends/widgets/gtk/window.py
+++ b/tv/lib/frontends/widgets/gtk/window.py
@@ -205,7 +205,7 @@ class Window(WindowBase):
 
     def destroy(self):
         self.close()
-        self._window.destroy()
+        self._window  = None
         alive_windows.discard(self)
 
     def is_active(self):
@@ -365,7 +365,7 @@ class DialogBase(WindowBase):
         raise NotImplementedError()
 
     def destroy(self):
-        self._window.destroy()
+        self._window = None
 
 class Dialog(DialogBase):
     def __init__(self, title, description=None):
@@ -421,9 +421,6 @@ class Dialog(DialogBase):
             return -1
         else:
             return response - 1 # response IDs started at 1
-
-    def destroy(self):
-        DialogBase.destroy(self)
 
     def set_extra_widget(self, widget):
         self.extra_widget = widget

--- a/tv/linux/plat/frontends/widgets/videoembed.py
+++ b/tv/linux/plat/frontends/widgets/videoembed.py
@@ -117,13 +117,10 @@ class GtkVideoWidget(gtk.DrawingArea):
             cr.fill()
 
     def destroy(self):
-        # unrealize if we need to
-        if self.flags() & gtk.REALIZED:
-            self.unrealize()
         # unset our renderer window
         self.renderer.set_window_id(None)
         # destroy our gstreamer window
-        self.gstreamer_window.destroy()
+        self.gstreamer_window = None
         # let DrawingArea take care of the rest
         gtk.DrawingArea.destroy(self)
 
@@ -162,4 +159,4 @@ class VideoWidget(base.Widget):
                 gtk.gdk.POINTER_MOTION_MASK)
 
     def destroy(self):
-        self._widget.destroy()
+        self._widget = None

--- a/tv/windows/plat/frontends/widgets/application.py
+++ b/tv/windows/plat/frontends/widgets/application.py
@@ -252,9 +252,6 @@ class WindowsApplication(Application):
     def quit_ui(self):
         logging.debug('Destroying EmbeddingWidgets')
         embeddingwidget.shutdown()
-        logging.debug('Destroying persistent window widgets')
-        for widget in persistentwindow.get_widgets():
-            widget.destroy()
         if hasattr(self, "trayicon"):
             logging.debug('Hiding tray icon')
             self.trayicon.set_visible(False)

--- a/tv/windows/plat/frontends/widgets/embeddingwidget.py
+++ b/tv/windows/plat/frontends/widgets/embeddingwidget.py
@@ -46,10 +46,8 @@ def init():
     embeddingwindow.init()
 
 def shutdown():
-    # copy _live_widgets since we will be changing it when we call destroy()
-    to_destroy = list(_live_widgets)
-    for widget in to_destroy:
-        widget.destroy()
+    # This should release the reference and it should garbage collect
+    _live_widgets = set()
 
 class EmbeddingWidget(gtk.DrawingArea):
     """EmbeddingWidget -- GTK widget for embedding other components."""

--- a/tv/windows/plat/frontends/widgets/videoembed.py
+++ b/tv/windows/plat/frontends/widgets/videoembed.py
@@ -94,4 +94,4 @@ class VideoWidget(base.Widget):
         self.renderer = renderer
 
     def destroy(self):
-        self._widget.destroy()
+        self._widget = None


### PR DESCRIPTION
Just let it garbage collect normally.  Destroy() releases PyGTK references
and may do bad things.

notes:

Ben had a look and he said it was okay.
Janet tested and she said it was okay.

There is some code in there that had a week reference to the persistent windows, but they only get torn down when miro shuts down. Since the reference is weak it probably cannot cause a leak/referencing issue.  If you are shutting down you release all resources anyway.  So I have removed those code since I am not really sure that's required.  If there's a good reason why that code should be there, please speak up.
