### PR TITLE
bz18285: Re-add the call to self.overlay.destroy().

### DIFF
--- a/tv/lib/frontends/widgets/gtk/video.py
+++ b/tv/lib/frontends/widgets/gtk/video.py
@@ -593,6 +593,7 @@ class VideoPlayer(player.GTKPlayer, VBox):
             self.pack_start(self._video_details)
             main_window.main_vbox.pack_start(main_window.controls_hbox)
 
+            self.overlay.destroy()
             self.overlay = None
 
     def rebuild_video_details(self):

--- a/tv/lib/frontends/widgets/gtk/window.py
+++ b/tv/lib/frontends/widgets/gtk/window.py
@@ -205,7 +205,7 @@ class Window(WindowBase):
 
     def destroy(self):
         self.close()
-        self._window  = None
+        self._window = None
         alive_windows.discard(self)
 
     def is_active(self):


### PR DESCRIPTION
It is needed because this is a signal emitter not a widget, so calling
destroy() is okay.  In addition the destroy() actually closes the window
which was the source of the regression.

Paul can you give it a spin and let me know how it goes for you?
