### PR TITLE
Fix wheezy helperscript

### DIFF
--- a/tv/linux/helperscripts/debian_wheezy.sh
+++ b/tv/linux/helperscripts/debian_wheezy.sh
@@ -33,7 +33,7 @@ apt-get install \
     python-gconf \
     python-pycurl \
     python-mutagen \
-    libboost1.42-dev \
+    libboost1.46-dev \
     libtag1-dev \
     zlib1g-dev \
     gstreamer0.10-ffmpeg \


### PR DESCRIPTION
Wheezy has libboost 1.46.  This fixes the helper script so it works.
