### PR TITLE
Fix closing the database upgrade dialog.

### DIFF
--- a/tv/lib/frontends/widgets/gtk/window.py
+++ b/tv/lib/frontends/widgets/gtk/window.py
@@ -365,7 +365,7 @@ class DialogBase(WindowBase):
         raise NotImplementedError()
 
     def destroy(self):
-        self._window = None
+        self._window.response(gtk.RESPONSE_NONE)
 
 class Dialog(DialogBase):
     def __init__(self, title, description=None):


### PR DESCRIPTION
Calling destroy() wasn't doing anything before.  This code fixes it.  It also
seems to work in the cases where we were calling destroy() after run()
returns, like newfeeddialog.py.
