### PR TITLE
bz18592. -strict experimental goes after the codec

### DIFF
--- a/tv/lib/conversions.py
+++ b/tv/lib/conversions.py
@@ -1042,8 +1042,8 @@ class FFMpegConversionTask(ConversionTask):
         default_parameters = build_parameters(
             self.input_path, self.temp_output_path, self.converter_info, media_info)
         # insert -strict experimental
-        default_parameters.insert(0, 'experimental')
-        default_parameters.insert(0, '-strict')
+        default_parameters.insert(-1, 'experimental')
+        default_parameters.insert(-2, '-strict')
         return utils.customize_ffmpeg_parameters(default_parameters)
 
     def check_for_errors(self, line):

--- a/tv/windows/plat/utils.py
+++ b/tv/windows/plat/utils.py
@@ -422,8 +422,6 @@ def get_ffmpeg_executable_path():
 
 def customize_ffmpeg_parameters(params):
     from miro.plat.specialfolders import get_short_path_name
-    # move -strict experimental to just before the output
-    params = params[2:-1] + params[:2] + params[-1:]
     # look for -i input
     ind = params.index("-i")
     if ind != -1 and len(params) > ind + 2:


### PR DESCRIPTION
This changeset moves it to just before the output.
