### PR TITLE
bz18664: Make sure that the sharing manager is available before using.

### DIFF
--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -322,6 +322,11 @@ def finish_startup(obj, thread):
     app.download_state_manager = downloader.DownloadStateManager()
     app.download_state_manager.init_controller()
 
+    # Call this late, after the message handlers have been installed.
+    app.sharing_tracker = sharing.SharingTracker()
+    app.sharing_manager = sharing.SharingManager()
+    app.transcode_manager = transcode.TranscodeManager()
+
     eventloop.add_urgent_call(check_firsttime, "check first time")
 
 def fix_database_inconsistencies():


### PR DESCRIPTION
Just a few days ago we put in some code that delayed the start of
the sharing manager and tracker to spread the workout out a little
bit.  Sadly, these two things are used at shutdown to checking if
there are outstanding connections (easy to fix) but also used
to manipulate sharing preferences (harder to address).

Let's put the startup of the sharing subsystem back where it was, since
that should be pretty quick, but track the items a bit later.
