### PR TITLE
bz18677: Make sure the net_lookup_enabled column is non-null.

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3722,3 +3722,10 @@ def upgrade172(cursor):
                    "ON metadata (status_id, source)")
     # drop old column
     remove_column(cursor, 'metadata', 'path')
+
+def upgrade173(cursor):
+    """Make sure net_lookup_enabled is always non-null."""
+    # This code should have been in upgrade170, but it's okay to run it now
+
+    cursor.execute("UPDATE metadata_status SET net_lookup_enabled=0 "
+                   "WHERE net_lookup_enabled IS NULL")

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -41,7 +41,7 @@ from miro import storedatabase
 def import_from_json(live_storage, json_db, mount):
     """Import data from a JSON DB for a newly created sqlite DB
 
-    This method basically does upgrades 166 through 172
+    This method basically does upgrades 166 through 173
 
     How to handle upgrades after this?  Who knows.  We're just worrying about
     making version 5.0 work at this point.

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1325,6 +1325,9 @@ def load_sqlite_database(mount, json_db, device_size):
                                              object_schemas=object_schemas)
     if not json_db.created_new and live_storage.created_new:
         devicedatabaseupgrade.import_from_json(live_storage, json_db, mount)
+    # force the version to match the current schema.  This is a hack to make
+    # databases from the nightlies match the ones from users starting with 5.0
+    live_storage.set_version(173)
     return live_storage
 
 def calc_sqlite_preallocate_size(device_size):

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -878,7 +878,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 172
+VERSION = 173
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/storedatabase.py
+++ b/tv/lib/storedatabase.py
@@ -694,7 +694,7 @@ class LiveStorage:
             databaseupgrade.new_style_upgrade(self.cursor,
                                               current_version,
                                               self._schema_version)
-            self._set_version()
+            self.set_version()
             self._change_database_file_back()
         self.current_version = self._schema_version
 
@@ -719,7 +719,7 @@ class LiveStorage:
                 if util.chatter:
                     logging.info("converting pre 2.1 database")
                 convert20database.convert(self.cursor)
-                self._set_version(80)
+                self.set_version(80)
                 self._change_database_file_back()
 
     def get_variable(self, name):
@@ -1245,7 +1245,7 @@ class LiveStorage:
                         (name, schema.table_name, ', '.join(columns)))
         self._create_variables_table()
         self.cursor.execute(iteminfocache.create_sql())
-        self._set_version()
+        self.set_version()
 
     def _get_size_info(self):
         """Get info about the database size
@@ -1294,7 +1294,7 @@ class LiveStorage:
     def _get_version(self):
         return self.get_variable(VERSION_KEY)
 
-    def _set_version(self, version=None, db_name='main'):
+    def set_version(self, version=None, db_name='main'):
         """Set the database version to the current schema version."""
 
         if version is None:


### PR DESCRIPTION
We were doing it for the item table, but I forget to put the same code for the
metadata_status table.

Adding upgrades is weird now that we have device SQL databases.  I think the
code now should do it.  devicedatabaseupgrade.import_from_json() did the right
thing from the start, so we don't need to run the upgrade for those databases.
Instead we just force the version to be 173 to fix databases for users who
have run the nightlies.
