### PR TITLE
bz18672: fix changing titles from the edit item box.

### DIFF
--- a/tv/lib/messagehandler.py
+++ b/tv/lib/messagehandler.py
@@ -1544,7 +1544,7 @@ New ids: %s""", playlist_item_ids, message.item_ids)
             except database.ObjectNotFoundError:
                 logging.warn("EditItems: Item not found -- %s", id_)
                 continue
-            # ItemInfo uses "name", but the metadat system uses "title" now
+            # ItemInfo uses "name", but the metadata system uses "title" now
             if 'name' in changes:
                 changes['title'] = changes.pop('name')
             item_.set_user_metadata(changes)

--- a/tv/lib/messagehandler.py
+++ b/tv/lib/messagehandler.py
@@ -1544,6 +1544,9 @@ New ids: %s""", playlist_item_ids, message.item_ids)
             except database.ObjectNotFoundError:
                 logging.warn("EditItems: Item not found -- %s", id_)
                 continue
+            # ItemInfo uses "name", but the metadat system uses "title" now
+            if 'name' in changes:
+                changes['title'] = changes.pop('name')
             item_.set_user_metadata(changes)
 
     def handle_revert_feed_title(self, message):


### PR DESCRIPTION
We just had to fix the key mismatch between ItemInfo and Item/Metadata.
