### PR TITLE
bz18664: Make sure delayed start is properly reverted.

### DIFF
--- a/tv/lib/sharing.py
+++ b/tv/lib/sharing.py
@@ -323,6 +323,8 @@ class SharingTracker(object):
                                  'DAAP test connect')
 
     def mdns_callback_backend(self, added, fullname, host, port):
+        # SAFE: the shared name should be unique.  (Or else you could not
+        # identify the resource).
         if fullname == app.sharing_manager.name:
             return
         # Need to come up with a unique ID for the share.  We want to use the 

--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -395,9 +395,6 @@ def fix_movies_gone():
     eventloop.add_urgent_call(finish_backend_startup, "reconnect downloaders")
 
 def start_sharing():
-    app.sharing_tracker = sharing.SharingTracker()
-    app.sharing_manager = sharing.SharingManager()
-    app.transcode_manager = transcode.TranscodeManager()
     app.sharing_tracker.start_tracking()
 
 @startup_function


### PR DESCRIPTION
Forgot to remove calls to initialization of the sharing manager and
tracker in the delayed portion so sharing was started twice.
