### PR TITLE
bz18686: Fix AttributeError in DownloadRateRenderer.

### DIFF
--- a/tv/lib/frontends/widgets/style.py
+++ b/tv/lib/frontends/widgets/style.py
@@ -362,8 +362,9 @@ class TorrentDetailsRenderer(ListViewRendererText):
 class DownloadRateRenderer(ListViewRendererText):
     right_aligned = True
 
-    def get_info(self, info):
+    def get_value(self, info):
         if info.state == 'downloading':
+            dl_info = info.download_info
             return displaytext.download_rate(dl_info.rate)
         else:
             return ''


### PR DESCRIPTION
This is a typo.  get_info() should really be get_value().
