### PR TITLE
bz18593: Fix styles for album view on GTK

### DIFF
--- a/tv/lib/frontends/widgets/gtk/tableview.py
+++ b/tv/lib/frontends/widgets/gtk/tableview.py
@@ -64,12 +64,22 @@ Rect = namedtuple('Rect', 'x y width height')
 
 _album_view_gtkrc_installed = False
 def _install_album_view_gtkrc():
-    """Hack for disabling the focus ring on the album view widget."""
+    """Hack for styling GTKTreeView for the album view widget.
+
+    We do a couple things:
+      - Remove the focus ring
+      - Remove any separator space.
+
+    We do this so that we don't draw a box through the album view column for
+    selected rows.
+    """
     global _album_view_gtkrc_installed
     if _album_view_gtkrc_installed:
         return
     rc_string = ('style "album-view-style"\n'
                  '{ \n'
+                 '  GtkTreeView::vertical-separator = 0\n'
+                 '  GtkTreeView::horizontal-separator = 0\n'
                  '  GtkWidget::focus-line-width = 0 \n'
                  '}\n'
                  'widget "*.miro-album-view" style "album-view-style"\n')


### PR DESCRIPTION
Extended the focus ring hack to change a couple other style properties that
can make things look funny.
