### PR TITLE
bz18671: don't run echonest for video files

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3732,3 +3732,20 @@ def upgrade173(cursor):
 
     cursor.execute("UPDATE metadata_status SET net_lookup_enabled=0 "
                    "WHERE net_lookup_enabled IS NULL")
+
+def upgrade174(cursor):
+    """Set some echonest_status to STATUS_SKIP_FROM_PREF instead of skipped."""
+
+    # for audio files, echonest_status should be STATUS_SKIP_FROM_PREF so that
+    # if the user enables echonest for that file it will run.  We keep
+    # video/other items as STATUS_SKIP, so that echonest will never run.
+    cursor.execute("UPDATE metadata_status SET echonest_status='P' "
+                   "WHERE id IN "
+                      "(SELECT status_id FROM metadata "
+                      "WHERE source = "
+                          "(SELECT source FROM metadata "
+                          "WHERE status_id=status_id AND "
+                          "file_type IS NOT NULL "
+                          "ORDER BY priority DESC LIMIT 1) AND "
+                      "file_type = 'audio')")
+

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -134,13 +134,17 @@ def _do_import(cursor, json_db, mount):
             current_processor = u'movie-data'
         else:
             current_processor = None
+        if file_type == u'audio':
+            echonest_status = 'P' # STATUS_SKIP_FROM_PREF
+        else:
+            echonest_status = 'S' # STATUS_SKIP
         sql = ("INSERT INTO metadata_status "
                "(id, path, current_processor, mutagen_status, "
                "moviedata_status, echonest_status, net_lookup_enabled, "
                "mutagen_thinks_drm, max_entry_priority) "
                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
         cursor.execute(sql, (next_id, path, current_processor, 'S',
-                             moviedata_status, 'N', False, has_drm,
+                             moviedata_status, echonest_status, False, has_drm,
                              OLD_ITEM_PRIORITY))
         status_id = next_id
         next_id += 1

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1328,7 +1328,7 @@ def load_sqlite_database(mount, json_db, device_size):
         devicedatabaseupgrade.import_from_json(live_storage, json_db, mount)
     # force the version to match the current schema.  This is a hack to make
     # databases from the nightlies match the ones from users starting with 5.0
-    live_storage.set_version(173)
+    live_storage.set_version(174)
     return live_storage
 
 def calc_sqlite_preallocate_size(device_size):

--- a/tv/lib/metadata.py
+++ b/tv/lib/metadata.py
@@ -81,6 +81,7 @@ class MetadataStatus(database.DDBObject):
     STATUS_COMPLETE = u'C'
     STATUS_FAILURE = u'F'
     STATUS_SKIP = u'S'
+    STATUS_SKIP_FROM_PREF = u'P'
 
     _source_name_to_status_column = {
         u'mutagen': 'mutagen_status',
@@ -96,7 +97,7 @@ class MetadataStatus(database.DDBObject):
         if self.net_lookup_enabled:
             self.echonest_status = self.STATUS_NOT_RUN
         else:
-            self.echonest_status = self.STATUS_SKIP
+            self.echonest_status = self.STATUS_SKIP_FROM_PREF
         self.mutagen_thinks_drm = False
         self.echonest_id = None
         self.max_entry_priority = -1
@@ -232,10 +233,10 @@ class MetadataStatus(database.DDBObject):
 
     def set_net_lookup_enabled(self, enabled):
         self.net_lookup_enabled = enabled
-        if enabled and self.echonest_status == self.STATUS_SKIP:
+        if enabled and self.echonest_status == self.STATUS_SKIP_FROM_PREF:
             self.echonest_status = self.STATUS_NOT_RUN
         elif not enabled and self.echonest_status == self.STATUS_NOT_RUN:
-            self.echonest_status = self.STATUS_SKIP
+            self.echonest_status = self.STATUS_SKIP_FROM_PREF
         self._set_current_processor()
         self.signal_change()
 

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -878,7 +878,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 173
+VERSION = 174
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/test/metadatatest.py
+++ b/tv/lib/test/metadatatest.py
@@ -334,15 +334,15 @@ class MetadataManagerTest(MiroTestCase):
         # movie data failing shouldn't change the metadata
         self.check_metadata(path)
 
-    def check_echonest_not_scheduled(self, filename):
+    def check_echonest_not_scheduled(self, filename, from_pref=False):
         self.check_echonest_not_running(filename)
         path = self.make_path(filename)
         status = metadata.MetadataStatus.get_by_path(path)
-        if status.echonest_status not in (status.STATUS_SKIP,
-                                          status.STATUS_COMPLETE):
-            raise AssertionError("Bad status in "
-                                 "check_echonest_not_scheduled(): %s" %
-                                 status.echonest_status)
+        if not from_pref:
+            self.assertEquals(status.echonest_status, status.STATUS_SKIP)
+        else:
+            self.assertEquals(status.echonest_status,
+                              status.STATUS_SKIP_FROM_PREF)
 
     def check_echonest_not_running(self, filename):
         path = self.make_path(filename)
@@ -494,7 +494,7 @@ class MetadataManagerTest(MiroTestCase):
         self.check_run_mutagen('foo.mp3', 'audio', 200, 'Bar', 'Fights')
         self.check_movie_data_not_scheduled('foo.mp3')
         self.check_echonest_not_running('foo.mp3')
-        self.check_echonest_not_scheduled('foo.mp3')
+        self.check_echonest_not_scheduled('foo.mp3', from_pref=True)
         # test that it starts running if we set the value to true
         self.check_set_net_lookup_enabled('foo.mp3', True)
         self.check_run_echonest('foo.mp3', 'Bar', 'Artist', 'Fights2')
@@ -1254,7 +1254,7 @@ class DeviceMetadataUpgradeTest(MiroTestCase):
         self.assertEquals(status.current_processor, u'movie-data')
         self.assertEquals(status.mutagen_status, status.STATUS_SKIP)
         self.assertEquals(status.moviedata_status, status.STATUS_NOT_RUN)
-        self.assertEquals(status.echonest_status, status.STATUS_NOT_RUN)
+        self.assertEquals(status.echonest_status, status.STATUS_SKIP_FROM_PREF)
         self.assertEquals(status.net_lookup_enabled, False)
 
     def check_migrated_entries(self, filename, item_data, device_db_info):


### PR DESCRIPTION
The issue was that we only had one status to track if we weren't going to run
echonest, STATUS_SKIP.  But we need to distinguish between skipping echonest
because the user has the preference turned off and skipping echonest because
its not an audio file.

Added new status to track this.  Added database upgrade that sets audio files
to have this status.  Fixed device database upgrade so that it sets the status
correctly in the first place.
