### PR TITLE
bz18718: fix race condition in subprocess tests

### DIFF
--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -328,6 +328,8 @@ class MiroTestCase(unittest.TestCase):
             patcher.stop()
         # shutdown workerprocess if we started it for some reason.
         workerprocess.shutdown()
+        workerprocess._subprocess_manager = \
+                workerprocess.WorkerSubprocessManager()
         workerprocess._miro_task_queue.reset()
         self.reset_log_filter()
         signals.system.disconnect_all()


### PR DESCRIPTION
The tests were hanging because sometimes we would quit with
SubprocessResponder.safe_to_skip_add_idle set True.  To avoid this we just
have to construct a fresh responder in tearDown.
