### PR TITLE
make sure `name_sort_key` return value is hashable

### DIFF
--- a/tv/lib/itemsource.py
+++ b/tv/lib/itemsource.py
@@ -156,7 +156,7 @@ class DatabaseItemSource(ItemSource):
     # bump this whenever you change the ItemInfo class, or change one of the
     # functions that ItemInfo uses to get it's attributes (for example
     # Item.get_description()).
-    VERSION = 38
+    VERSION = 39
 
     def __init__(self, view):
         ItemSource.__init__(self)

--- a/tv/lib/test/utiltest.py
+++ b/tv/lib/test/utiltest.py
@@ -813,14 +813,24 @@ class TestCopySubtitleFile(unittest.TestCase):
 class TestNameSortKey(unittest.TestCase):
     def test_simple(self):
         for testcase in ((None, 'ZZZZZZZZZZZZZ'),
-                         (u'', [u'']),
-                         (u'a', [u'a']),
-                         (u'a1a', [u'a', 1.0, u'a']),
-                         (u'Episode_100', [u'episode_', 100.0, u'']),
-                         (u'episode_1', [u'episode_', 1.0, u''])
+                         (u'', (u'',)),
+                         (u'a', (u'a',)),
+                         (u'a1a', (u'a', 1.0, u'a')),
+                         (u'Episode_100', (u'episode_', 100.0, u'')),
+                         (u'episode_1', (u'episode_', 1.0, u''))
                          ):
             self.assertEquals(util.name_sort_key(testcase[0]),
                               testcase[1])
+
+    def test_hashable(self):
+        for testcase in (None,
+                         u'',
+                         u'a',
+                         u'a1a',
+                         u'Episode_100',
+                         u'episode_1',
+                         ):
+            hash(util.name_sort_key(testcase))
 
     def test_sorting(self):
         for inlist, outlist in (

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -1050,7 +1050,7 @@ def name_sort_key(text):
         text = text[2:] + ', a'
     elif text.startswith("the "):
         text = text[4:] + ', the'
-    return [_trynum(c) for c in NUM_RE.split(text)]
+    return tuple(_trynum(c) for c in NUM_RE.split(text))
 
 LOWER_TRANSLATE = string.maketrans(string.ascii_uppercase,
                                    string.ascii_lowercase)


### PR DESCRIPTION
Before it was a list, which was causing lots of errors in InfoList when it
tried to use the sort key as a dictionary key.
