### PR TITLE
bz17781: don't re-download icons for items.

### DIFF
--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -1912,7 +1912,8 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
 
     def update_from_feed_parser_values(self, fp_values):
         fp_values.update_item(self)
-        self.icon_cache.request_update()
+        if self.icon_cache.filename is None:
+            self.icon_cache.request_update()
         self.signal_change()
 
     def on_download_finished(self):


### PR DESCRIPTION
Pretty simple change, I think I just didn't want to do it late in the release
cycle last time.
