### PR TITLE
bz18737. magnet torrents get stuck in starting up

### DIFF
--- a/tv/lib/dl_daemon/download.py
+++ b/tv/lib/dl_daemon/download.py
@@ -1111,7 +1111,12 @@ class BTDownloader(BGDownloader):
             # disadvantage of extra disk i/o because of pieces are moved
             # on the fly rather than being placed into its logical location
             # within the file but makes everything else usable again.
-            params["storage_mode"] = lt.storage_mode_t.storage_mode_compact
+            if self.magnet:
+                # unfortunately, compact allocation doesn't work for Magnet
+                # links, so we revert to the allocate mode
+                params["storage_mode"] = lt.storage_mode_t.storage_mode_allocate
+            else:
+                params["storage_mode"] = lt.storage_mode_t.storage_mode_compact
 
             if self.info_hash:
                 self.fast_resume_data = load_fast_resume_data(self.info_hash)


### PR DESCRIPTION
Magnet links don't appear to work with the compact storage mode.  If we're
downloading a magnet file, fall back to the old allocate storage mode.
