### PR TITLE
Allow users to pass --g-fatal-warnings on the command line

### DIFF
--- a/tv/linux/miro.real
+++ b/tv/linux/miro.real
@@ -117,6 +117,10 @@ group.add_option('--sync',
                  action="store_true",
                  help='Use X synchronously.')
 parser.set_defaults(sync=False)
+group.add_option('--g-fatal-warnings',
+                 action="store_true")
+# NOTE: we don't actually do anything with g-fatal-warnings, but it gets
+# picked up by the GTK code.
 group.add_option('--gconf-name',
                  dest='gconf_name',
                  metavar='<NAME>',


### PR DESCRIPTION
Small improvement I had while trying to figure out #17243.
