### PR TITLE
bz18735: Make sure we keep a valid reference to window for hiding.

### DIFF
--- a/tv/lib/frontends/widgets/gtk/window.py
+++ b/tv/lib/frontends/widgets/gtk/window.py
@@ -200,8 +200,11 @@ class Window(WindowBase):
         if hasattr(self, "_closing"):
             return
         self._closing = True
+        # Keep a reference to the widget in case will-close signal handler
+        # calls destroy()
+        old_window = self._window
         self.emit('will-close')
-        self._window.hide()
+        old_window.hide()
         del self._closing
 
     def destroy(self):


### PR DESCRIPTION
will-close runs an arbitrary signal handler which could call destroy()
and nuke the window widget.  Make sure we keep a reference to it so we
can still hide it on return.
