### PR TITLE
Fix18756

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3772,3 +3772,21 @@ def upgrade176(cursor):
     # Set file_type to other for items that the subquery returned 0 rows for
     cursor.execute("UPDATE metadata_status SET file_type='other' "
                    "WHERE file_type IS NULL")
+
+def upgrade177(cursor):
+    """Add finished_status, remove current_processor from metadata_status."""
+    cursor.execute("ALTER TABLE metadata_status ADD finished_status INTEGER")
+    # set finished_status to 1 (the current versionas of 5.0) if
+    # current_processor was None
+    cursor.execute("UPDATE metadata_status "
+                   "SET finished_status=1 "
+                   "WHERE current_processor IS NULL")
+    # set finished_status to 0 (unfinished) for all other rows)
+    cursor.execute("UPDATE metadata_status "
+                   "SET finished_status=0 "
+                   "WHERE current_processor IS NOT NULL")
+    cursor.execute("CREATE INDEX metadata_finished ON "
+                   "metadata_status (finished_status)")
+    # drop the current_processor column
+    cursor.execute("DROP INDEX metadata_processor")
+    remove_column(cursor, 'metadata_status', ['current_processor'])

--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3749,3 +3749,11 @@ def upgrade174(cursor):
                           "ORDER BY priority DESC LIMIT 1) AND "
                       "file_type = 'audio')")
 
+def upgrade175(cursor):
+    """Rename screenshot_path and cover_art_path back to their old names."""
+
+    rename_column(cursor, 'metadata', 'screenshot_path', 'screenshot')
+    alter_table_columns(cursor, 'item', [], rename_columns={
+        'screenshot_path': 'screenshot',
+        'cover_art_path': 'cover_art',
+    })

--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3757,3 +3757,18 @@ def upgrade175(cursor):
         'screenshot_path': 'screenshot',
         'cover_art_path': 'cover_art',
     })
+
+def upgrade176(cursor):
+    """Add file_type to metadata_status."""
+    # Add file_type to metadata_status and set it to the file_type from the
+    # metadata table
+    cursor.execute("ALTER TABLE metadata_status ADD file_type TEXT")
+    cursor.execute("UPDATE metadata_status "
+                   "SET file_type=("
+                      "SELECT file_type FROM metadata "
+                      "WHERE status_id=metadata_status.id AND "
+                      "file_type IS NOT NULL "
+                      "ORDER BY priority DESC LIMIT 1)")
+    # Set file_type to other for items that the subquery returned 0 rows for
+    cursor.execute("UPDATE metadata_status SET file_type='other' "
+                   "WHERE file_type IS NULL")

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -37,6 +37,7 @@ import urllib
 
 from miro import app
 from miro import databaseupgrade
+from miro import item
 from miro import metadata
 from miro import prefs
 from miro import storedatabase
@@ -222,7 +223,7 @@ class _do_import_old_items(object):
         # versions from running the movie data program on them.  This seems
         # the safest option and old versions should still pick up new metadata
         # when newer versions run MDP.
-        old_item['mdp_state'] = 1
+        old_item['mdp_state'] = item.MDP_STATE_RAN
 
     def insert_into_metadata_status(self, path, file_type, finished_status,
                                     mutagen_status, moviedata_status,

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -37,6 +37,7 @@ import urllib
 
 from miro import app
 from miro import databaseupgrade
+from miro import metadata
 from miro import prefs
 from miro import storedatabase
 
@@ -175,9 +176,9 @@ class _DoImportOldItems(object):
             finished_status = 1
 
         if self.net_lookup_enabled:
-            echonest_status = 'N' # STATUS_NOT_RUN
+            echonest_status = metadata.MetadataStatus.STATUS_NOT_RUN
         else:
-            echonest_status = 'S' # STATUS_SKIP
+            echonest_status = metadata.MetadataStatus.STATUS_SKIP
         status_id = self.insert_into_metadata_status(
             path, file_type, finished_status, 'S', moviedata_status,
             echonest_status, has_drm, OLD_ITEM_PRIORITY)
@@ -251,7 +252,7 @@ class _DoImportOldItems(object):
         # make a metadata_status row for each item in the database as if they
         # were just added
 
-        STATUS_NOT_RUN = 'N'
+        STATUS_NOT_RUN = metadata.MetadataStatus.STATUS_NOT_RUN
         self.insert_into_metadata_status(path, file_type, 0, STATUS_NOT_RUN,
                                          STATUS_NOT_RUN, STATUS_NOT_RUN,
                                          False, 0)

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -151,9 +151,9 @@ def _do_import_old_items(cursor, json_db, mount):
         # SKIPPED.  moviedata_status is based on the old mdp_state column
         moviedata_status = mdp_state_map[old_item.get('mdp_state')]
         if moviedata_status == 'N':
-            current_processor = u'movie-data'
+            finished_status = 0
         else:
-            current_processor = None
+            finished_status = 1
 
         net_lookup_enabled = app.config.get(prefs.NET_LOOKUP_BY_DEFAULT)
         if net_lookup_enabled:
@@ -161,11 +161,11 @@ def _do_import_old_items(cursor, json_db, mount):
         else:
             echonest_status = 'S' # STATUS_SKIP
         sql = ("INSERT INTO metadata_status "
-               "(id, path, file_type, current_processor, mutagen_status, "
+               "(id, path, file_type, finished_status, mutagen_status, "
                "moviedata_status, echonest_status, net_lookup_enabled, "
                "mutagen_thinks_drm, max_entry_priority) "
                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
-        cursor.execute(sql, (next_id, path, file_type, current_processor, 'S',
+        cursor.execute(sql, (next_id, path, file_type, finished_status, 'S',
                              moviedata_status, echonest_status,
                              net_lookup_enabled, has_drm, OLD_ITEM_PRIORITY))
         status_id = next_id
@@ -235,7 +235,7 @@ def handle_failed_upgrade(cursor, json_db):
     # just added
 
     sql = ("INSERT INTO metadata_status "
-           "(path, current_processor, mutagen_status, moviedata_status, "
+           "(path, finished_status, mutagen_status, moviedata_status, "
            "echonest_status, net_lookup_enabled, mutagen_thinks_drm, "
            "max_entry_priority) VALUES (?, ?, ?, ?, ?, ?, ?, ?)")
 
@@ -246,6 +246,6 @@ def handle_failed_upgrade(cursor, json_db):
         if file_type not in json_db:
             continue
         for path in json_db[file_type].keys():
-           values = (path, u'mutagen', STATUS_NOT_RUN, STATUS_NOT_RUN,
+           values = (path, 0, STATUS_NOT_RUN, STATUS_NOT_RUN,
                      STATUS_NOT_RUN, net_lookup_enabled, False, 0)
            cursor.execute(sql, values)

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -191,10 +191,8 @@ class _do_import_old_items(object):
         # mutagen completed successfully or not, so we just call its status
         # SKIPPED.  moviedata_status is based on the old mdp_state column
         moviedata_status = self.mdp_state_map[old_item.get('mdp_state')]
-        if moviedata_status == 'N':
-            finished_status = 0
-        else:
-            finished_status = 1
+        finished_status = bool(moviedata_status !=
+                               metadata.MetadataStatus.STATUS_NOT_RUN)
 
         if self.net_lookup_enabled:
             echonest_status = metadata.MetadataStatus.STATUS_NOT_RUN

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -39,17 +39,19 @@ from miro import databaseupgrade
 from miro import prefs
 from miro import storedatabase
 
-def import_from_json(live_storage, json_db, mount):
-    """Import data from a JSON DB for a newly created sqlite DB
+def import_old_items(live_storage, json_db, mount):
+    """Import items in a JSON database from old versions.
 
-    This method basically does upgrades 166 through 173
+    For each item in the JSON db that doesn't have a corresponding entry in
+    the metadata status table, we import that data into the metadata table.
+    This method basically does upgrades 166 through 173 for those items.
 
     How to handle upgrades after this?  Who knows.  We're just worrying about
     making version 5.0 work at this point.
     """
     live_storage.cursor.execute("BEGIN TRANSACTION")
     try:
-        _do_import(live_storage.cursor, json_db, mount)
+        _do_import_old_items(live_storage.cursor, json_db, mount)
     except StandardError:
         logging.exception('exception while importing JSON db from %s', mount)
         action = live_storage.error_handler.handle_upgrade_error()
@@ -61,9 +63,12 @@ def import_from_json(live_storage, json_db, mount):
     finally:
         live_storage.cursor.execute("COMMIT TRANSACTION")
 
-def _do_import(cursor, json_db, mount):
+def _do_import_old_items(cursor, json_db, mount):
     # FIXME: this code is tied to the 5.0 release and may not work for future
     # versions
+
+    cursor.execute("SELECT path FROM metadata_status")
+    paths_in_new_system = set(row[0] for row in cursor)
 
     cover_art_dir = os.path.join(mount, '.miro', 'cover-art')
     # map old MDP states to their new values
@@ -76,17 +81,30 @@ def _do_import(cursor, json_db, mount):
 
     device_items = []
     for file_type in (u'audio', u'video', u'other'):
+        if file_type not in json_db:
+            continue
         for path, data in json_db[file_type].iteritems():
-            device_items.append((file_type, path, data))
+            if path not in paths_in_new_system:
+                device_items.append((file_type, path, data))
 
-    # currently get_title() returns the contents of title and falls back on
-    # title_tag.  Set the title column to be that value for the conversion and
-    # erase title_tag
+    if not device_items:
+        # nothing new to import
+        return
+
+    logging.info("Importing %d old device items", len(device_items))
+
+    # title and title_tag were pretty confusing before 5.0.  We would set
+    # title_tag based on the ID3 tags, and if that didn't work, then set title
+    # based on the filename.  get_title() would try the title attribute first,
+    # then fallback to title_tag.  After 5.0, we just only use title.
+    #
+    # This code should make it so that titles work correctly for upgraded
+    # items, both in 5.0 and also if you go back to a pre-5.0 versions.
     for file_type, path, item in device_items:
         if 'title_tag' in item:
             if not item['title']:
                 item['title'] = item['title_tag']
-            del item['title_tag']
+            item['title_tag'] = None
 
     # list that contains tuples in the form of
     # (metadata_column_name, device_item_key
@@ -177,10 +195,11 @@ def _do_import(cursor, json_db, mount):
 
         if 'cover_art' in old_item:
             upgrade_cover_art(old_item, cover_art_dir)
-        if 'mdp_state' in old_item:
-            del old_item['mdp_state']
-        if 'metadata_version' in old_item:
-            del old_item['metadata_version']
+        # Use the RAN state for all old items.  This will prevent old miro
+        # versions from running the movie data program on them.  This seems
+        # the safest option and old versions should still pick up new metadata
+        # when newer versions run MDP.
+        old_item['mdp_state'] = 1
 
 def upgrade_cover_art(device_item, cover_art_dir):
     """Drop the cover_art field and move cover art to a filename based on the
@@ -190,6 +209,7 @@ def upgrade_cover_art(device_item, cover_art_dir):
     if 'album' not in device_item or 'cover_art' not in device_item:
         return
     cover_art = device_item.pop('cover_art')
+    device_item['cover_art'] = None # default in case the upgrade fails.
     # quote the filename using the same logic as
     # filetags.calc_cover_art_filename()
     dest_filename = urllib.quote(device_item['album'].encode('utf-8'),
@@ -205,6 +225,8 @@ def upgrade_cover_art(device_item, cover_art_dir):
         except StandardError:
             logging.warn("upgrade_cover_art: Error moving %s -> %s", 
                          cover_art, dest_path)
+            return
+    device_item['cover_art'] = dest_path
 
 def handle_failed_upgrade(cursor, json_db):
     # make a metadata_status row for each item in the database as if they were
@@ -224,13 +246,4 @@ def handle_failed_upgrade(cursor, json_db):
         for path in json_db[file_type].keys():
            values = (path, u'mutagen', STATUS_NOT_RUN, STATUS_NOT_RUN,
                      STATUS_NOT_RUN, net_lookup_enabled, False, 0)
-           try:
-               cursor.execute(sql, values)
-           except storedatabase.sqlite3.IntegrityError, e:
-               if e.message == 'column path is not unique': # XXX better way to
-                                                            # detect this?
-                   # This item already got added to the DB during a partial
-                   # upgrade; skip adding a row to the DB.
-                   pass
-               else:
-                   raise
+           cursor.execute(sql, values)

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -154,18 +154,20 @@ def _do_import_old_items(cursor, json_db, mount):
             current_processor = u'movie-data'
         else:
             current_processor = None
-        if file_type == u'audio':
-            echonest_status = 'P' # STATUS_SKIP_FROM_PREF
+
+        net_lookup_enabled = app.config.get(prefs.NET_LOOKUP_BY_DEFAULT)
+        if net_lookup_enabled:
+            echonest_status = 'N' # STATUS_NOT_RUN
         else:
             echonest_status = 'S' # STATUS_SKIP
         sql = ("INSERT INTO metadata_status "
-               "(id, path, current_processor, mutagen_status, "
+               "(id, path, file_type, current_processor, mutagen_status, "
                "moviedata_status, echonest_status, net_lookup_enabled, "
                "mutagen_thinks_drm, max_entry_priority) "
-               "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
-        cursor.execute(sql, (next_id, path, current_processor, 'S',
-                             moviedata_status, echonest_status, False, has_drm,
-                             OLD_ITEM_PRIORITY))
+               "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        cursor.execute(sql, (next_id, path, file_type, current_processor, 'S',
+                             moviedata_status, echonest_status,
+                             net_lookup_enabled, has_drm, OLD_ITEM_PRIORITY))
         status_id = next_id
         next_id += 1
 

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -96,7 +96,7 @@ def _do_import(cursor, json_db, mount):
         ('album_artist', 'album_artist'),
         ('album_tracks', 'album_tracks'),
         ('artist', 'artist'),
-        ('screenshot_path', 'screenshot'),
+        ('screenshot', 'screenshot'),
         ('drm', 'has_drm'),
         ('genre', 'genre'),
         ('title ', 'title'),
@@ -177,8 +177,6 @@ def _do_import(cursor, json_db, mount):
 
         if 'cover_art' in old_item:
             upgrade_cover_art(old_item, cover_art_dir)
-        if 'screenshot' in old_item:
-            old_item['screenshot_path'] = old_item.pop('screenshot')
         if 'mdp_state' in old_item:
             del old_item['mdp_state']
         if 'metadata_version' in old_item:
@@ -191,22 +189,22 @@ def upgrade_cover_art(device_item, cover_art_dir):
 
     if 'album' not in device_item or 'cover_art' not in device_item:
         return
-    cover_art_path = device_item.pop('cover_art')
+    cover_art = device_item.pop('cover_art')
     # quote the filename using the same logic as
     # filetags.calc_cover_art_filename()
     dest_filename = urllib.quote(device_item['album'].encode('utf-8'),
                                  safe=' ,.')
     dest_path = os.path.join(cover_art_dir, dest_filename)
     if not os.path.exists(dest_path):
-        if not os.path.exists(cover_art_path):
+        if not os.path.exists(cover_art):
             logging.warn("upgrade_cover_art: Error moving cover art, "
-                         "source path doesn't exist: %s", cover_art_path)
+                         "source path doesn't exist: %s", cover_art)
             return
         try:
-            shutil.move(cover_art_path, dest_path)
+            shutil.move(cover_art, dest_path)
         except StandardError:
             logging.warn("upgrade_cover_art: Error moving %s -> %s", 
-                         cover_art_path, dest_path)
+                         cover_art, dest_path)
 
 def handle_failed_upgrade(cursor, json_db):
     # make a metadata_status row for each item in the database as if they were

--- a/tv/lib/devicedatabaseupgrade.py
+++ b/tv/lib/devicedatabaseupgrade.py
@@ -53,7 +53,7 @@ def import_old_items(live_storage, json_db, mount):
     """
     live_storage.cursor.execute("BEGIN TRANSACTION")
     try:
-        _DoImportOldItems(live_storage.cursor, json_db, mount).invoke()
+        _do_import_old_items(live_storage.cursor, json_db, mount)
         live_storage.cursor.execute("COMMIT TRANSACTION")
     except StandardError:
         logging.exception('exception while importing JSON db from %s', mount)
@@ -63,7 +63,7 @@ def import_old_items(live_storage, json_db, mount):
             logging.warn("Unexpected return value from the error handler for "
                          "a device database: %s" % action)
 
-class _DoImportOldItems(object):
+class _do_import_old_items(object):
     """Function object that handles the work for import_old_items"""
 
     # FIXME: this code is tied to the 5.0 release and may not work for future
@@ -131,7 +131,6 @@ class _DoImportOldItems(object):
         # track the next id that we should create in the database
         self.id_counter = itertools.count(databaseupgrade.get_next_id(cursor))
 
-    def invoke(self):
         if not self.device_items:
             # nothing new to import
             return

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1344,10 +1344,14 @@ def load_sqlite_database(mount, json_db, device_size, countdown=0):
         # make databases from the nightlies match the ones from users starting
         # with 5.0
         live_storage.set_version(DB_VERSION)
-    elif live_storage.get_version() != DB_VERSION:
-        # we don't support upgrading databases because the only ones that need
-        # upgrading are ones that have gone through the nightlys.  Just
-        # re-create the database in this case
+    elif live_storage.get_version() < DB_VERSION:
+        # Hack for 5.0.
+        #
+        # We didn't create sqlite databases in 4.0.x, so if there is a
+        # database with an earlier version, we know it was created by a
+        # nightly build.  In that case it's not a huge deal to reset it.
+        #
+        # FIXME: Need to write real upgrade code for post-5.0
         logging.warn("Reseting device database: %r", mount)
         live_storage.reset_database(init_db=True)
 

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1338,11 +1338,19 @@ def load_sqlite_database(mount, json_db, device_size, countdown=0):
             time.sleep(0.20 * 1.2 ** countdown)
             return load_sqlite_database(mount, json_db, device_size,
                                         countdown + 1)
+    DB_VERSION = 177
     if live_storage.created_new:
         # force the version to match the current schema.  This is a hack to
         # make databases from the nightlies match the ones from users starting
         # with 5.0
-        live_storage.set_version(174)
+        live_storage.set_version(DB_VERSION)
+    elif live_storage.get_version() != DB_VERSION:
+        # we don't support upgrading databases because the only ones that need
+        # upgrading are ones that have gone through the nightlys.  Just
+        # re-create the database in this case
+        logging.warn("Reseting device database: %r", mount)
+        live_storage.reset_database(init_db=True)
+
     devicedatabaseupgrade.import_old_items(live_storage, json_db, mount)
     return live_storage
 

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1338,11 +1338,12 @@ def load_sqlite_database(mount, json_db, device_size, countdown=0):
             time.sleep(0.20 * 1.2 ** countdown)
             return load_sqlite_database(mount, json_db, device_size,
                                         countdown + 1)
-    if not json_db.created_new and live_storage.created_new:
-        devicedatabaseupgrade.import_from_json(live_storage, json_db, mount)
-    # force the version to match the current schema.  This is a hack to make
-    # databases from the nightlies match the ones from users starting with 5.0
-    live_storage.set_version(174)
+    if live_storage.created_new:
+        # force the version to match the current schema.  This is a hack to
+        # make databases from the nightlies match the ones from users starting
+        # with 5.0
+        live_storage.set_version(174)
+    devicedatabaseupgrade.import_old_items(live_storage, json_db, mount)
     return live_storage
 
 def calc_sqlite_preallocate_size(device_size):

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1353,7 +1353,7 @@ def load_sqlite_database(mount, json_db, device_size, countdown=0):
         #
         # FIXME: Need to write real upgrade code for post-5.0
         logging.warn("Reseting device database: %r", mount)
-        live_storage.reset_database(init_db=True)
+        live_storage.reset_database(init_schema=True)
 
     devicedatabaseupgrade.import_old_items(live_storage, json_db, mount)
     return live_storage

--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1344,16 +1344,24 @@ def load_sqlite_database(mount, json_db, device_size, countdown=0):
         # make databases from the nightlies match the ones from users starting
         # with 5.0
         live_storage.set_version(DB_VERSION)
-    elif live_storage.get_version() < DB_VERSION:
-        # Hack for 5.0.
-        #
-        # We didn't create sqlite databases in 4.0.x, so if there is a
-        # database with an earlier version, we know it was created by a
-        # nightly build.  In that case it's not a huge deal to reset it.
-        #
-        # FIXME: Need to write real upgrade code for post-5.0
-        logging.warn("Reseting device database: %r", mount)
-        live_storage.reset_database(init_schema=True)
+    else:
+        device_db_version = live_storage.get_version()
+        if device_db_version < DB_VERSION:
+            # Hack for 5.0.
+            #
+            # We didn't create sqlite databases in 4.0.x, so if there is a
+            # database with an earlier version, we know it was created by a
+            # nightly build.  In that case it's not a huge deal to reset it.
+            #
+            # FIXME: Need to write real upgrade code for post-5.0
+            logging.warn("Reseting device database: %r", mount)
+            live_storage.reset_database(init_schema=True)
+        elif device_db_version > DB_VERSION:
+            # Newer versions of miro should store their device databases in a
+            # way that's compatible with previous ones.  We just have to hope
+            # that's true in this case.
+            logging.warn("database from newer miro version: %r (version=%s)",
+                         mount, device_db_version)
 
     devicedatabaseupgrade.import_old_items(live_storage, json_db, mount)
     return live_storage

--- a/tv/lib/dialogs.py
+++ b/tv/lib/dialogs.py
@@ -174,6 +174,12 @@ class Dialog(object):
                                     "%s callback" % self.__class__,
                                     args=(self,))
 
+    def __str__(self):
+        button_text = '/'.join(b.text for b in self.buttons)
+        return "%s (text: %s, buttons: %s)" % (self.__class__,
+                                               self.title,
+                                               button_text)
+
 class MessageBoxDialog(Dialog):
     """Show the user some info in a dialog box.  The only button is
     Okay.  The callback is optional for a message box dialog.

--- a/tv/lib/echonest.py
+++ b/tv/lib/echonest.py
@@ -340,7 +340,7 @@ class _EchonestQuery(object):
             self.grab_url_dest = os.path.join(self.cover_art_dir,
                                               self.cover_art_filename)
             if os.path.exists(self.grab_url_dest):
-                self.metadata['cover_art_path'] = self.grab_url_dest
+                self.metadata['cover_art'] = self.grab_url_dest
                 self.invoke_callback()
             else:
                 self.fetch_cover_art()
@@ -400,7 +400,7 @@ class _EchonestQuery(object):
     def cover_art_callback(self, data):
         # we don't care about the data sent back, since grab_url wrote our
         # file for us
-        self.metadata['cover_art_path'] = self.grab_url_dest
+        self.metadata['cover_art'] = self.grab_url_dest
         self.metadata['created_cover_art'] = True
         self.invoke_callback()
 

--- a/tv/lib/feed.py
+++ b/tv/lib/feed.py
@@ -703,7 +703,7 @@ class Feed(DDBObject, iconcache.IconCacheOwnerMixin):
         self.signal_change(needs_save=False)
         for item in self.items:
             if not item.icon_cache or not (item.icon_cache.is_valid() or
-                    item.screenshot_path or
+                    item.screenshot or
                     item.isContainerItem):
                 item.signal_change(needs_save=False)
 

--- a/tv/lib/filetags.py
+++ b/tv/lib/filetags.py
@@ -374,5 +374,5 @@ def _parse_mutagen(filename, muta, cover_art_directory):
                                               cover_art_directory)
         del data['cover_art']
     if cover_art_info is not None:
-        data['cover_art_path'], data['created_cover_art'] = cover_art_info
+        data['cover_art'], data['created_cover_art'] = cover_art_info
     return data

--- a/tv/lib/frontends/widgets/itemedit.py
+++ b/tv/lib/frontends/widgets/itemedit.py
@@ -325,7 +325,7 @@ class ThumbnailField(DialogOwnerMixin, Field):
     TITLE = _("Choose a thumbnail file")
     DIALOG = widgetset.FileOpenDialog
     def __init__(self, items, label):
-        Field.__init__(self, 'cover_art_path', items, label)
+        Field.__init__(self, 'cover_art', items, label)
         DialogOwnerMixin.__init__(self, self.DIALOG, self.TITLE)
         path = self.common_value
 

--- a/tv/lib/frontends/widgets/style.py
+++ b/tv/lib/frontends/widgets/style.py
@@ -812,8 +812,8 @@ class _MultiRowAlbumRenderStrategy(object):
 
 class _StandardRenderStrategy(_MultiRowAlbumRenderStrategy):
     def get_image_path(self, item_info, first_info):
-        if item_info.cover_art_path is not None:
-            return item_info.cover_art_path
+        if item_info.cover_art is not None:
+            return item_info.cover_art
         else:
             return item_info.thumbnail
 

--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -82,6 +82,10 @@ MIME_SUBSITUTIONS = {
     u'QUICKTIME': u'MOV',
 }
 
+# We don't mdp_state as of version 5.0, but we need to set this for
+# DeviceItems so that older versions can read the device DB
+MDP_STATE_RAN = 1
+
 def _check_for_image(path, element):
     """Given an element (which is really a dict), traverses
     the path in the element and if that turns out to be an image,
@@ -2429,7 +2433,7 @@ class DeviceItem(object):
         self._fix_paths_from_database(kwargs)
         # set values for attributes used in pre-5.0 databases.
         self.metadata_version = 5 # version used in 4.0.x
-        self.mdp_state = 1 # RAN stat
+        self.mdp_state = MDP_STATE_RAN
         self.title_tag = None
 
         self.__dict__.update(kwargs)

--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -431,7 +431,7 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
         self.filename = None
         self.eligibleForAutoDownload = eligibleForAutoDownload
         self.duration = None
-        self.screenshot_path = None
+        self.screenshot = None
         self.resumeTime = 0
         self.channelTitle = None
         self.downloader_id = None
@@ -1484,8 +1484,8 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
         to signal the right set of items.
         """
         self.confirm_db_thread()
-        if self.cover_art_path:
-            path = self.cover_art_path
+        if self.cover_art:
+            path = self.cover_art
             path = resources.path(fileutil.expand_filename(path))
             if fileutil.exists(path):
                 return path
@@ -1493,8 +1493,8 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
             # is_valid() verifies that the path exists
             path = self.icon_cache.get_filename()
             return resources.path(fileutil.expand_filename(path))
-        if self.screenshot_path:
-            path = self.screenshot_path
+        if self.screenshot:
+            path = self.screenshot
             path = resources.path(fileutil.expand_filename(path))
             if fileutil.exists(path):
                 return path
@@ -2413,7 +2413,7 @@ class DeviceItem(object):
         self.url = self.payment_link = None
         self.comments_link = self.permalink = self.file_url = None
         self.license = self.downloader = None
-        self.duration = self.screenshot_path = self.thumbnail_url = None
+        self.duration = self.screenshot = self.thumbnail_url = None
         self.resumeTime = 0
         self.subtitle_encoding = self.enclosure_type = None
         self.auto_sync = False
@@ -2458,9 +2458,9 @@ class DeviceItem(object):
         self.__initialized = True
 
     def _fix_paths_from_database(self, data):
-        """Make screenshot_path and cover_art_path the correct type.
+        """Make screenshot and cover_art the correct type.
         """
-        for key in ('screenshot_path', 'cover_art_path'):
+        for key in ('screenshot', 'cover_art'):
             if key in data and isinstance(data[key], unicode):
                 data[key] = utf8_to_filename(data[key].encode('utf-8'))
 
@@ -2509,12 +2509,12 @@ class DeviceItem(object):
 
     @returns_filename
     def get_thumbnail(self):
-        if self.cover_art_path:
+        if self.cover_art:
             return os.path.join(self.device.mount,
-                                self.cover_art_path)
-        elif self.screenshot_path:
+                                self.cover_art)
+        elif self.screenshot:
             return os.path.join(self.device.mount,
-                                self.screenshot_path)
+                                self.screenshot)
         elif self.file_type == 'audio':
             return resources.path("images/thumb-default-audio.png")
         else:
@@ -2563,7 +2563,7 @@ class DeviceItem(object):
         for k, v in self.__dict__.items():
             if v is not None and k not in (u'device', u'file_type', u'id',
                                            u'video_path', u'_deferred_update'):
-                if ((k == u'screenshot_path' or k == u'cover_art_path')):
+                if ((k == u'screenshot' or k == u'cover_art')):
                     v = filename_to_unicode(v)
                 data[k] = v
         return data

--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -2427,6 +2427,11 @@ class DeviceItem(object):
         else:
             local_path = None
         self._fix_paths_from_database(kwargs)
+        # set values for attributes used in pre-5.0 databases.
+        self.metadata_version = 5 # version used in 4.0.x
+        self.mdp_state = 1 # RAN stat
+        self.title_tag = None
+
         self.__dict__.update(kwargs)
 
         if isinstance(self.video_path, unicode):
@@ -2505,6 +2510,13 @@ class DeviceItem(object):
         """
         if self.title:
             return self.title
+        if self.title_tag:
+            # title_tag was set to the ID3 tag by pre-5.0 versions.  We
+            # convert this to title_tag in
+            # devicedatabaseupgrade.import_old_items(), so this probably won't
+            # be reached.  But we might as well prefer title_tag over the
+            # filename if it somehow exists.
+            return self.title_tag
         return os.path.basename(self.id)
 
     @returns_filename

--- a/tv/lib/moviedata.py
+++ b/tv/lib/moviedata.py
@@ -33,7 +33,7 @@ from miro import download_utils
 from miro import fileutil
 from miro.plat.utils import run_media_metadata_extractor
 
-def convert_mdp_result(source_path, screenshot_path, result):
+def convert_mdp_result(source_path, screenshot, result):
     """Convert the movie data program result for the metadata manager
     """
     converted_result = { 'source_path': source_path }
@@ -59,8 +59,8 @@ def convert_mdp_result(source_path, screenshot_path, result):
         converted_result['file_type'] = u'video'
 
     if (converted_result.get('file_type') == 'video' and success and
-        fileutil.exists(screenshot_path)):
-        converted_result['screenshot_path'] = screenshot_path
+        fileutil.exists(screenshot)):
+        converted_result['screenshot'] = screenshot
     return converted_result
 
 def _make_screenshot_path(source_path, image_directory):
@@ -85,8 +85,8 @@ def process_file(source_path, image_directory):
     :param image_directory: directory to put screenshut files
     :returns: dictionary with metadata info
     """
-    screenshot_path, fp = _make_screenshot_path(source_path, image_directory)
-    result = run_media_metadata_extractor(source_path, screenshot_path)
+    screenshot, fp = _make_screenshot_path(source_path, image_directory)
+    result = run_media_metadata_extractor(source_path, screenshot)
     # we can close the file now, since MDP has written to it
     fp.close()
-    return convert_mdp_result(source_path, screenshot_path, result)
+    return convert_mdp_result(source_path, screenshot, result)

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -824,7 +824,7 @@ class MetadataStatusSchema(DDBObjectSchema):
     fields = DDBObjectSchema.fields + [
         ('path', SchemaFilename()),
         ('file_type', SchemaString()),
-        ('current_processor', SchemaString(noneOk=True)),
+        ('finished_status', SchemaInt()),
         ('mutagen_status', SchemaString()),
         ('moviedata_status', SchemaString()),
         ('echonest_status', SchemaString()),
@@ -835,7 +835,7 @@ class MetadataStatusSchema(DDBObjectSchema):
     ]
 
     indexes = (
-        ('metadata_processor', ('current_processor',)),
+        ('metadata_finished', ('finished_status',)),
     )
 
     unique_indexes = (
@@ -879,7 +879,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 176
+VERSION = 177
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -450,7 +450,7 @@ class ItemSchema(MultiClassObjectSchema):
         ('releaseDateObj', SchemaDateTime()),
         ('eligibleForAutoDownload', SchemaBool()),
         ('duration', SchemaInt(noneOk=True)),
-        ('screenshot_path', SchemaFilename(noneOk=True)),
+        ('screenshot', SchemaFilename(noneOk=True)),
         ('resumeTime', SchemaInt()),
         ('channelTitle', SchemaString(noneOk=True)),
         ('license', SchemaString(noneOk=True)),
@@ -474,7 +474,7 @@ class ItemSchema(MultiClassObjectSchema):
         ('play_count', SchemaInt()),
         ('skip_count', SchemaInt()),
         # metadata:
-        ('cover_art_path', SchemaFilename(noneOk=True)),
+        ('cover_art', SchemaFilename(noneOk=True)),
         ('title', SchemaString(noneOk=True)),
         ('description', SchemaString(noneOk=True)),
         ('album', SchemaString(noneOk=True)),
@@ -854,7 +854,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('album_artist', SchemaString(noneOk=True)),
         ('album_tracks', SchemaInt(noneOk=True)),
         ('artist', SchemaString(noneOk=True)),
-        ('screenshot_path', SchemaFilename(noneOk=True)),
+        ('screenshot', SchemaFilename(noneOk=True)),
         ('drm', SchemaBool(noneOk=True)),
         ('genre', SchemaString(noneOk=True)),
         ('title', SchemaString(noneOk=True)),
@@ -878,7 +878,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 174
+VERSION = 175
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -823,6 +823,7 @@ class MetadataStatusSchema(DDBObjectSchema):
     table_name = 'metadata_status'
     fields = DDBObjectSchema.fields + [
         ('path', SchemaFilename()),
+        ('file_type', SchemaString()),
         ('current_processor', SchemaString(noneOk=True)),
         ('mutagen_status', SchemaString()),
         ('moviedata_status', SchemaString()),
@@ -878,7 +879,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 175
+VERSION = 176
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/test/devicestest.py
+++ b/tv/lib/test/devicestest.py
@@ -383,7 +383,7 @@ class DeviceDatabaseTest(MiroTestCase):
         os.remove(os.path.join(self.device.mount, '.miro', 'sqlite'))
         mock_do_import = mock.Mock()
         method = ('miro.devicedatabaseupgrade.'
-                  '_DoImportOldItems.convert_old_item')
+                  '_do_import_old_items.convert_old_item')
         patcher = mock.patch(method, mock_do_import)
         mock_do_import.side_effect = sqlite3.DatabaseError("Error")
         self.device.database.created_new = False

--- a/tv/lib/test/devicestest.py
+++ b/tv/lib/test/devicestest.py
@@ -383,7 +383,7 @@ class DeviceDatabaseTest(MiroTestCase):
         # Force our upgrade code to run and throw an exception.
         os.remove(os.path.join(self.device.mount, '.miro', 'sqlite'))
         mock_do_import = mock.Mock()
-        patcher = mock.patch('miro.devicedatabaseupgrade._do_import',
+        patcher = mock.patch('miro.devicedatabaseupgrade._do_import_old_items',
                              mock_do_import)
         mock_do_import.side_effect = sqlite3.DatabaseError("Error")
         self.device.database.created_new = False

--- a/tv/lib/test/filetagstest.py
+++ b/tv/lib/test/filetagstest.py
@@ -46,10 +46,10 @@ class FileTagsTest(MiroTestCase):
         if cover_art:
             # cover art should be stored using the album name as its file
             correct_path = path.join(self.tempdir, results['album'])
-            self.assertEquals(results.pop('cover_art_path'), correct_path)
+            self.assertEquals(results.pop('cover_art'), correct_path)
             self.assertEquals(results.pop('created_cover_art'), True)
         else:
-            self.assert_('cover_art_path' not in results)
+            self.assert_('cover_art' not in results)
         # for the rest, we just compare the dicts
         self.assertEquals(results, expected)
 
@@ -68,19 +68,19 @@ class FileTagsTest(MiroTestCase):
 
         # process the first file
         result_1 = process_file(dest_paths[0], self.tempdir)
-        self.assertEquals(result_1['cover_art_path'],
+        self.assertEquals(result_1['cover_art'],
                           path.join(self.tempdir, result_1['album']))
-        self.assert_(path.exists(result_1['cover_art_path']))
-        org_mtime = stat(result_1['cover_art_path']).st_mtime
+        self.assert_(path.exists(result_1['cover_art']))
+        org_mtime = stat(result_1['cover_art']).st_mtime
 
-        # process the rest, they should fill in the cover_art_path value, but
+        # process the rest, they should fill in the cover_art value, but
         # not rewrite the file
         for dup_path in dest_paths[1:]:
             results = process_file(dup_path, self.tempdir)
-            self.assertEquals(results['cover_art_path'],
-                              result_1['cover_art_path'])
-            self.assert_(path.exists(results['cover_art_path']))
-            self.assertEquals(stat(results['cover_art_path']).st_mtime,
+            self.assertEquals(results['cover_art'],
+                              result_1['cover_art'])
+            self.assert_(path.exists(results['cover_art']))
+            self.assertEquals(stat(results['cover_art']).st_mtime,
                               org_mtime)
 
 @dynamic_test()

--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -272,6 +272,7 @@ class MiroTestCase(unittest.TestCase):
         item.start_deleted_checker()
         # Skip worker proccess for feedparser
         feed._RUN_FEED_PARSER_INLINE = True
+        signals.system.connect('new-dialog', self.handle_new_dialog)
         # reload config and initialize it to temprary
         config.load_temporary()
         self.setup_config_watcher()
@@ -348,6 +349,13 @@ class MiroTestCase(unittest.TestCase):
 
         # Remove tempdir
         shutil.rmtree(self.tempdir, onerror=self._on_rmtree_error)
+
+    def handle_new_dialog(self, obj, dialog):
+        """Handle the new-dialog signal
+
+        Subclasses must implement this if they expect to see a dialog.
+        """
+        raise AssertionError("Unexpected dialog: %s" % dialog)
 
     def patch_function(self, function_name, new_function):
         """Use Mock to replace an existing function for a single test.

--- a/tv/lib/test/metadatatest.py
+++ b/tv/lib/test/metadatatest.py
@@ -341,15 +341,11 @@ class MetadataManagerTest(MiroTestCase):
         # movie data failing shouldn't change the metadata
         self.check_metadata(path)
 
-    def check_echonest_not_scheduled(self, filename, from_pref=False):
+    def check_echonest_not_scheduled(self, filename):
         self.check_echonest_not_running(filename)
         path = self.make_path(filename)
         status = metadata.MetadataStatus.get_by_path(path)
-        if not from_pref:
-            self.assertEquals(status.echonest_status, status.STATUS_SKIP)
-        else:
-            self.assertEquals(status.echonest_status,
-                              status.STATUS_SKIP_FROM_PREF)
+        self.assertEquals(status.echonest_status, status.STATUS_SKIP)
 
     def check_echonest_not_running(self, filename):
         path = self.make_path(filename)
@@ -504,7 +500,7 @@ class MetadataManagerTest(MiroTestCase):
         self.check_run_mutagen('foo.mp3', 'audio', 200, 'Bar', 'Fights')
         self.check_movie_data_not_scheduled('foo.mp3')
         self.check_echonest_not_running('foo.mp3')
-        self.check_echonest_not_scheduled('foo.mp3', from_pref=True)
+        self.check_echonest_not_scheduled('foo.mp3')
         # test that it starts running if we set the value to true
         self.check_set_net_lookup_enabled('foo.mp3', True)
         self.check_run_echonest('foo.mp3', 'Bar', 'Artist', 'Fights2')
@@ -1355,7 +1351,7 @@ class DeviceMetadataUpgradeTest(MiroTestCase):
         self.assertEquals(status.current_processor, u'movie-data')
         self.assertEquals(status.mutagen_status, status.STATUS_SKIP)
         self.assertEquals(status.moviedata_status, status.STATUS_NOT_RUN)
-        self.assertEquals(status.echonest_status, status.STATUS_SKIP_FROM_PREF)
+        self.assertEquals(status.echonest_status, status.STATUS_SKIP)
         self.assertEquals(status.net_lookup_enabled, False)
 
     def check_migrated_entries(self, filename, item_data, device_db_info):

--- a/tv/lib/test/metadatatest.py
+++ b/tv/lib/test/metadatatest.py
@@ -177,9 +177,9 @@ class MetadataManagerTest(MiroTestCase):
             metadata['net_lookup_enabled'] = False
         metadata.update(self.user_info_data[path])
         if 'album' in metadata:
-            cover_art_path = self.cover_art_for_album(metadata['album'])
-            if cover_art_path:
-                metadata['cover_art_path'] = cover_art_path
+            cover_art = self.cover_art_for_album(metadata['album'])
+            if cover_art:
+                metadata['cover_art'] = cover_art
         # created_cover_art is used by MetadataManager, but it's not saved to
         # the metadata table
         if 'created_cover_art' in metadata:
@@ -193,28 +193,28 @@ class MetadataManagerTest(MiroTestCase):
         self.check_metadata(path)
 
     def cover_art_for_album(self, album_name):
-        mutagen_cover_art_path = None
-        echonest_cover_art_path = None
+        mutagen_cover_art = None
+        echonest_cover_art = None
         for metadata in self.mutagen_data.values():
-            if ('album' in metadata and 'cover_art_path' in metadata and
+            if ('album' in metadata and 'cover_art' in metadata and
                 metadata['album'] == album_name):
-                if (mutagen_cover_art_path is not None and
-                    metadata['cover_art_path'] != mutagen_cover_art_path):
-                    raise AssertionError("Different mutagen cover_art_path "
+                if (mutagen_cover_art is not None and
+                    metadata['cover_art'] != mutagen_cover_art):
+                    raise AssertionError("Different mutagen cover_art "
                                          "for " + album_name)
-                mutagen_cover_art_path = metadata['cover_art_path']
+                mutagen_cover_art = metadata['cover_art']
         for metadata in self.echonest_data.values():
-            if ('album' in metadata and 'cover_art_path' in metadata and
+            if ('album' in metadata and 'cover_art' in metadata and
                 metadata['album'] == album_name):
-                if (echonest_cover_art_path is not None and
-                    metadata['cover_art_path'] != echonest_cover_art_path):
-                    raise AssertionError("Different mutagen cover_art_path "
+                if (echonest_cover_art is not None and
+                    metadata['cover_art'] != echonest_cover_art):
+                    raise AssertionError("Different mutagen cover_art "
                                          "for " + album_name)
-                echonest_cover_art_path = metadata['cover_art_path']
-        if echonest_cover_art_path:
-            return echonest_cover_art_path
+                echonest_cover_art = metadata['cover_art']
+        if echonest_cover_art:
+            return echonest_cover_art
         else:
-            return mutagen_cover_art_path
+            return mutagen_cover_art
 
     def check_metadata(self, filename):
         path = self.make_path(filename)
@@ -252,7 +252,7 @@ class MetadataManagerTest(MiroTestCase):
         # ValueError
         self.assertRaises(ValueError, self.metadata_manager.add_file, path)
 
-    def cover_art_path(self, album_name, echonest=False):
+    def cover_art(self, album_name, echonest=False):
         path_parts = [self.tempdir]
         if echonest:
             path_parts.append('echonest')
@@ -275,11 +275,11 @@ class MetadataManagerTest(MiroTestCase):
             mutagen_data['album'] = unicode(album)
         mutagen_data['drm'] = drm
         if cover_art and album is not None:
-            cover_art_path = self.cover_art_path(album)
-            mutagen_data['cover_art_path'] = cover_art_path
-            if not os.path.exists(cover_art_path):
+            cover_art = self.cover_art(album)
+            mutagen_data['cover_art'] = cover_art
+            if not os.path.exists(cover_art):
                 # simulate read_metadata() writing the mutagen_data file
-                open(cover_art_path, 'wb').write("FAKE FILE")
+                open(cover_art, 'wb').write("FAKE FILE")
                 mutagen_data['created_cover_art'] = True
         self.mutagen_data[path] = mutagen_data
         self.processor.run_mutagen_callback(path, mutagen_data)
@@ -330,7 +330,7 @@ class MetadataManagerTest(MiroTestCase):
             moviedata_data['duration'] = duration
         if screenshot_worked:
             ss_path = self.get_screenshot_path(filename)
-            moviedata_data['screenshot_path'] = ss_path
+            moviedata_data['screenshot'] = ss_path
         self.movieprogram_data[path] = moviedata_data
         self.processor.run_movie_data_callback(path, moviedata_data)
         self.check_metadata(path)
@@ -397,11 +397,11 @@ class MetadataManagerTest(MiroTestCase):
             echonest_data['artist'] = unicode(artist)
         if album is not None:
             echonest_data['album'] = unicode(album)
-            cover_art_path = self.cover_art_path(album, True)
-            echonest_data['cover_art_path'] = cover_art_path
+            cover_art = self.cover_art(album, True)
+            echonest_data['cover_art'] = cover_art
             # simulate grab_url() writing the mutagen_data file
-            if not os.path.exists(cover_art_path):
-                open(cover_art_path, 'wb').write("FAKE FILE")
+            if not os.path.exists(cover_art):
+                open(cover_art, 'wb').write("FAKE FILE")
                 echonest_data['created_cover_art'] = True
         self.echonest_data[path] = echonest_data
         self.processor.run_echonest_callback(path, echonest_data)
@@ -701,9 +701,9 @@ class MetadataManagerTest(MiroTestCase):
             self.make_path('foo-4.mp3'),
         ])
         for filename in ('foo.mp3', 'foo-2.mp3'):
-            cover_art_path = self.cover_art_for_album('Fights')
+            cover_art = self.cover_art_for_album('Fights')
             self.assertEquals(new_metadata[self.make_path(filename)], {
-                'cover_art_path': cover_art_path,
+                'cover_art': cover_art,
             })
         # test that if we get more cover art for the same file, we don't
         # re-update the other items
@@ -1227,15 +1227,15 @@ class DeviceMetadataTest(EventLoopTest):
         self.assertEquals(device_item.album, u'Album')
 
     def test_image_paths(self):
-        # Test that screenshot_path and cover_art_path are relative to the
+        # Test that screenshot and cover_art are relative to the
         # device
-        screenshot_path = os.path.join(self.device.mount, '.miro',
+        screenshot = os.path.join(self.device.mount, '.miro',
                                        'icon-cache', 'extracted',
                                        'screenshot.png')
-        cover_art_path = os.path.join(self.device.mount, '.miro', 'cover-art',
+        cover_art = os.path.join(self.device.mount, '.miro', 'cover-art',
                                       unicode_to_filename(u'Album'))
-        self.moviedata_metadata['screenshot_path'] = screenshot_path
-        for path in (screenshot_path, cover_art_path):
+        self.moviedata_metadata['screenshot'] = screenshot
+        for path in (screenshot, cover_art):
             if not os.path.exists(os.path.dirname(path)):
                 os.makedirs(os.path.dirname(path))
             open(path, 'w').write("FAKE DATA")
@@ -1243,10 +1243,10 @@ class DeviceMetadataTest(EventLoopTest):
         self.make_device_item()
         self.run_processors()
         item_metadata = self.get_metadata_for_item()
-        self.assertEquals(item_metadata['screenshot_path'],
-                          os.path.relpath(screenshot_path, self.device.mount))
-        self.assertEquals(item_metadata['cover_art_path'],
-                          os.path.relpath(cover_art_path, self.device.mount))
+        self.assertEquals(item_metadata['screenshot'],
+                          os.path.relpath(screenshot, self.device.mount))
+        self.assertEquals(item_metadata['cover_art'],
+                          os.path.relpath(cover_art, self.device.mount))
 
     def test_remove(self):
         # Test that we remove metadata entries for removed DeviceItems.
@@ -1647,7 +1647,7 @@ class TestEchonestQueries(MiroTestCase):
             return
         if response_file == self.bossanova_release_id:
             self.reply_metadata['album'] = 'Bossanova'
-            self.reply_metadata['cover_art_path'] = os.path.join(
+            self.reply_metadata['cover_art'] = os.path.join(
                 self.album_art_dir, 'Bossanova')
             self.reply_metadata['created_cover_art'] = True
             self.reply_metadata['album_artist'] = 'Pixies'
@@ -1659,7 +1659,7 @@ class TestEchonestQueries(MiroTestCase):
             # arbitrarily
             self.reply_metadata['album'] = 'Thriller'
             self.reply_metadata['album_artist'] = 'Michael Jackson'
-            self.reply_metadata['cover_art_path'] = os.path.join(
+            self.reply_metadata['cover_art'] = os.path.join(
                 self.album_art_dir, 'Thriller')
             self.reply_metadata['created_cover_art'] = True
             self.album_art_url = (
@@ -1746,9 +1746,9 @@ class TestEchonestQueries(MiroTestCase):
         self.send_7digital_reply(self.bossanova_release_id)
         self.check_album_art_grab_url_call()
         self.send_http_error()
-        # we shouldn't have cover_art_path in the reply, since the request
+        # we shouldn't have cover_art in the reply, since the request
         # failed
-        del self.reply_metadata['cover_art_path']
+        del self.reply_metadata['cover_art']
         del self.reply_metadata['created_cover_art']
         self.check_callback()
 

--- a/tv/lib/test/subprocesstest.py
+++ b/tv/lib/test/subprocesstest.py
@@ -343,10 +343,10 @@ class MovieDataTest(WorkerProcessTest):
             self.assert_('duration' not in self.result)
         if file_type == 'video':
             screenshot_name = os.path.basename(source_path) + '.png'
-            self.assertEquals(self.get_from_result('screenshot_path'),
+            self.assertEquals(self.get_from_result('screenshot'),
                               os.path.join(self.tempdir, screenshot_name))
         else:
-            self.assert_('screenshot_path' not in self.result)
+            self.assert_('screenshot' not in self.result)
         self.reset_results()
 
     def test_movie_data_worker_process(self):
@@ -375,9 +375,9 @@ class MutagenTest(WorkerProcessTest):
         self.assertEquals(self.result['duration'], duration)
         self.assertEquals(self.result['title'], title)
         if has_cover_art:
-            self.assertNotEquals(self.result['cover_art_path'], None)
+            self.assertNotEquals(self.result['cover_art'], None)
         else:
-            self.assert_('cover_art_path' not in self.result)
+            self.assert_('cover_art' not in self.result)
         self.reset_results()
 
     def test_mutagen_worker_process(self):

--- a/tv/lib/test/unicodetest.py
+++ b/tv/lib/test/unicodetest.py
@@ -12,11 +12,10 @@ from miro.plat import resources
 class UnicodeFeedTestCase(framework.EventLoopTest):
     def setUp(self):
         super(UnicodeFeedTestCase, self).setUp()
-        signals.system.connect('new-dialog', self.onNewDialog)
         self.choice = None
         self.num_dialogs = 0
 
-    def onNewDialog(self, obj, dialog):
+    def handle_new_dialog(self, obj, dialog):
         self.assertNotEqual(self.choice, None)
         self.num_dialogs += 1
         # print "rundialog called from %s" % dialog.title


### PR DESCRIPTION
Janet gives this the thumbs up.  This is ready to merge, assuming the peer-review is okay.

The main point of all of this is to try to make device database handling work better as devices pass between miro versions.  This meant making it so that the current code outputs things in a way that previous versions can deal with.

Also it meant trying to change the metadata/metadata_status schemas in a way so that future versions can change the schema and still work with this version.  I'm thinking the process would go something like this:
- Suppose Miro 6.0 adds a new metadata processor called "foo"
- we add a foo_status column and set it to noneOk=True.  I think this means that older versions can still read/write to the database and when it writes to the database the column is set to NULL.
- if NULL isn't okay, we can add code that runs an upgrade by selecting all the rows where foo_status is NULL.
- We change the value that gets set to finished_status to 2.  This way if miro 6.0 sets finished_status, then Miro 5.0 will know that it doesn't need to run any metadata processors either.  But if Miro 5.0 sets it, then Miro 6.0 will still get a chance to run the new processor.
