### PR TITLE
bz18803: make exceptions derive from StandardError

### DIFF
--- a/tv/lib/coverart.py
+++ b/tv/lib/coverart.py
@@ -42,11 +42,11 @@ from miro import prefs
 from miro import util
 from miro import fileutil
 
-class UnknownImageObjectException(Exception):
+class UnknownImageObjectException(StandardError):
     """Image uses this when mutagen gives us something strange.
     """
     def __init__(self, object_type, known_types):
-        Exception.__init__(self)
+        StandardError.__init__(self)
         self.object_type = object_type
         self.known_types = known_types
 

--- a/tv/lib/database.py
+++ b/tv/lib/database.py
@@ -35,10 +35,8 @@ import threading
 from miro import app
 from miro import signals
 
-class DatabaseException(Exception):
-    """Superclass for classes that subclass Exception and are all
-    Database related.
-    """
+class DatabaseException(StandardError):
+    """Superclass database errors."""
     pass
 
 class DatabaseConstraintError(DatabaseException):

--- a/tv/lib/databasesanity.py
+++ b/tv/lib/databasesanity.py
@@ -44,7 +44,7 @@ from miro import feed
 from miro import signals
 from miro import guide
 
-class DatabaseInsaneError(Exception):
+class DatabaseInsaneError(StandardError):
     pass
 
 class SanityTest(object):

--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -57,7 +57,7 @@ from miro import prefs
 # looks nicer as a return value
 NO_CHANGES = set()
 
-class DatabaseTooNewError(Exception):
+class DatabaseTooNewError(StandardError):
     """Error that we raise when we see a database that is newer than
     the version that we can update too.
     """
@@ -1832,7 +1832,7 @@ def upgrade75(objectList):
                     rv = self.first_video_enclosure["text"]
                 elif hasattr(self.entry, "description"):
                     rv = self.entry.description
-            except Exception:
+            except StandardError:
                 logging.exception("_calc_raw_description threw exception:")
             if rv is None:
                 return u''

--- a/tv/lib/dl_daemon/daemon.py
+++ b/tv/lib/dl_daemon/daemon.py
@@ -47,7 +47,7 @@ from miro import util
 
 SIZE_OF_INT = calcsize("I")
 
-class DaemonError(Exception):
+class DaemonError(StandardError):
     """Exception while communicating to a daemon (either controller or
     downloader).
     """

--- a/tv/lib/frontends/widgets/menus.py
+++ b/tv/lib/frontends/widgets/menus.py
@@ -568,7 +568,7 @@ def on_profile_message():
 def on_profile_redraw():
     app.widgetapp.profile_redraw()
 
-class TestIntentionalCrash(Exception):
+class TestIntentionalCrash(StandardError):
     pass
 
 @action_handler("TestCrashReporter")

--- a/tv/lib/libdaap/pybonjour.py
+++ b/tv/lib/libdaap/pybonjour.py
@@ -246,7 +246,7 @@ kDNSServiceInterfaceIndexLocalOnly  = -1
 
 
 
-class BonjourError(Exception):
+class BonjourError(StandardError):
 
     """
 
@@ -288,8 +288,8 @@ class BonjourError(Exception):
 
     def __init__(self, errorCode):
         self.errorCode = errorCode
-        Exception.__init__(self,
-                           (errorCode, self._errmsg.get(errorCode, 'unknown')))
+        StandardError.__init__(self,
+                               (errorCode, self._errmsg.get(errorCode, 'unknown')))
 
 
 

--- a/tv/lib/net.py
+++ b/tv/lib/net.py
@@ -65,7 +65,7 @@ except (ImportError, AttributeError):
     def convert_to_ssl(sock):
         return socket.ssl(sock)
 
-class NetworkError(Exception):
+class NetworkError(StandardError):
     """Base class for all errors that will be passed to errbacks from get_url
     and friends.  NetworkErrors can be display in 2 ways:
 

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -52,7 +52,7 @@ import time
 from types import NoneType
 from miro.plat.utils import PlatformFilenameType
 
-class ValidationError(Exception):
+class ValidationError(StandardError):
     """Error thrown when we try to save invalid data."""
     pass
 

--- a/tv/lib/schemav79.py
+++ b/tv/lib/schemav79.py
@@ -55,7 +55,7 @@ import time
 from types import NoneType
 from miro.plat.utils import PlatformFilenameType
 
-class ValidationError(Exception):
+class ValidationError(StandardError):
     """Error thrown when we try to save invalid data."""
     pass
 

--- a/tv/lib/searchengines.py
+++ b/tv/lib/searchengines.py
@@ -42,7 +42,7 @@ from miro import prefs
 import logging
 from miro.gtcache import gettext as _
 
-class IntentionalCrash(Exception):
+class IntentionalCrash(StandardError):
     pass
 
 class SearchEngineInfo:

--- a/tv/lib/signals.py
+++ b/tv/lib/signals.py
@@ -39,7 +39,7 @@ import weakref
 
 from miro import crashreport
 
-class NestedSignalError(Exception):
+class NestedSignalError(StandardError):
     pass
 
 class WeakMethodReference:

--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -92,7 +92,7 @@ from miro.plat import devicetracker
 DEBUG_DB_MEM_USAGE = False
 mem_usage_test_event = threading.Event()
 
-class StartupError(Exception):
+class StartupError(StandardError):
     def __init__(self, summary, description):
         self.summary = summary
         self.description = description
@@ -110,9 +110,7 @@ def startup_function(func):
             else:
                 m = messages.FrontendQuit()
             m.send_to_frontend()
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception, exc:
+        except StandardError, exc:
             # we do this so that we only kick up the database error
             # if it's a database-related exception AND the app has a
             # db attribute

--- a/tv/lib/storedatabase.py
+++ b/tv/lib/storedatabase.py
@@ -80,7 +80,7 @@ from miro import util
 from miro.gtcache import gettext as _
 from miro.plat.utils import PlatformFilenameType, filename_to_unicode
 
-class UpgradeError(Exception):
+class UpgradeError(StandardError):
     """While upgrading the database, we ran out of disk space."""
     pass
 
@@ -600,10 +600,7 @@ class LiveStorage:
         """Run any database upgrades that haven't been run."""
         try:
             self._upgrade_database()
-        except (KeyError, SystemError,
-                databaseupgrade.DatabaseTooNewError):
-            raise
-        except Exception, e:
+        except StandardError, e:
             logging.exception('error when upgrading database: %s', e)
             self._handle_upgrade_error()
 

--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -147,7 +147,7 @@ def skip_for_platforms(*platforms):
     else:
         return identity
 
-class HadToStopEventLoop(Exception):
+class HadToStopEventLoop(StandardError):
     pass
 
 class DummyMainFrame:

--- a/tv/windows/plat/frontends/widgets/XULRunnerBrowser/xulrunnerbrowser.pyx
+++ b/tv/windows/plat/frontends/widgets/XULRunnerBrowser/xulrunnerbrowser.pyx
@@ -167,7 +167,7 @@ def add_cookie(name, value, domain, path, expiry):
     if rv != NS_OK:
        raise XPCOMError("add_cookie failed with code: %d" % rv)
 
-class XPCOMError(Exception):
+class XPCOMError(StandardError):
     pass
 
 cdef void focusCallbackGlue(PRBool forward, void* data) with gil:

--- a/tv/windows/plat/pipeipc.py
+++ b/tv/windows/plat/pipeipc.py
@@ -61,13 +61,13 @@ PIPE_WAIT = 0x00000000
 
 MIRO_IPC_PIPE_NAME = r'\\.\pipe\MiroIPC'
 
-class PipeExists(Exception):
+class PipeExists(StandardError):
     """We tried to create a named pipe, but it already exists.  Probably a
     different Miro instance created it.
     """
     pass
 
-class QuitThread(Exception):
+class QuitThread(StandardError):
     """Raised to exit out of the pipe listening thread.
     """
     pass


### PR DESCRIPTION
Changed code in a few places to only catch StandardErrors rather than having
separate code for KeyError/SystemError.

I'm not 100% sure that it's a good idea to merge this at this point in the dev cycle, but I'm leaning towards merging it.  Another way to do it would be to only change the base classes, not the except statements.
