### PR TITLE
Bz18632

### DIFF
--- a/tv/windows/plat/frontends/widgets/embeddingwidget.py
+++ b/tv/windows/plat/frontends/widgets/embeddingwidget.py
@@ -46,8 +46,13 @@ def init():
     embeddingwindow.init()
 
 def shutdown():
-    # This should release the reference and it should garbage collect
-    _live_widgets = set()
+    # XXX Force a destroy of all outstanding embedding widgets.  Otherwise we
+    # may get mysterious hangs on Windows (bz18632).  But breaking this sort
+    # of open reference is probably bad; we should investigate more how to fix
+    # this properly.
+    to_destroy = list(_live_widgets)
+    for d in to_destroy:
+        d.destroy()
 
 class EmbeddingWidget(gtk.DrawingArea):
     """EmbeddingWidget -- GTK widget for embedding other components."""
@@ -77,7 +82,7 @@ class EmbeddingWidget(gtk.DrawingArea):
         gtk.DrawingArea.do_realize(self)
         # attach our embedded window to our window
         self.embedding_window.attach(self.window.handle,
-                *self._get_window_area())
+                                     *self._get_window_area())
 
     def do_unrealize(self):
         # detach our embedded window


### PR DESCRIPTION
```
bz18632: Fix shutdown on Windows.

Windows gets very sad if we don't get a chance to free the C-based
embedding widget; and relying on the garbage collection to call destroy()
isn't good because you could still have open references.  But we don't
want to call destroy() explicitly to destroy objects in case there is still
someone using it.

But empirically it seems changing it to just destroy the embedding window
is not enough so there must be something else involved.  Anyway, revert
that part of the change for now so that it all works.
```
