### PR TITLE
bz18705: Change blip.tv to Blip.

### DIFF
--- a/tv/resources/searchengines/bliptv.xml
+++ b/tv/resources/searchengines/bliptv.xml
@@ -1,6 +1,6 @@
 <searchengine>
    <id>bliptv</id>
-   <displayname>blip.tv</displayname>
+   <displayname>Blip</displayname>
    <url>http://blip.tv/?1=1&amp;search=%s;s=posts&amp;skin=rss</url>
    <sort>7</sort>
 </searchengine>


### PR DESCRIPTION
I've only changed the display name and kept the internals the same and
things should continue to work as normal.
