### PR TITLE
bz18840: don't run movie data on non-media files.

### DIFF
--- a/tv/lib/metadata.py
+++ b/tv/lib/metadata.py
@@ -246,10 +246,16 @@ class MetadataStatus(database.DDBObject):
         #     audio)
         #   - mutagen was able to get the duration for the file
         #   - mutagen doesn't think the file has DRM
-        return ((my_ext == '.oga' or not my_ext.startswith('.og')) and
-                entry.file_type == 'audio' and
-                entry.duration is not None and
-                not entry.drm)
+        if ((my_ext == '.oga' or not my_ext.startswith('.og')) and
+            entry.file_type == 'audio' and
+            entry.duration is not None and
+            not entry.drm):
+            return True
+        # We should also skip it if mutagen couldn't identify the file and the
+        # extension indicates it's a non-media file
+        if entry.file_type is None and filetypes.is_other_filename(self.path):
+            return True
+        return False
 
     def update_after_error(self, source_name, error):
         """Update after we failed to extract some metadata.

--- a/tv/lib/moviedata.py
+++ b/tv/lib/moviedata.py
@@ -39,14 +39,14 @@ def convert_mdp_result(source_path, screenshot, result):
     converted_result = { 'source_path': source_path }
     file_type, duration, success = result
 
-    # MDP retuturns durations in millseconds, convert to seconds
     if duration >= 0:
         converted_result['duration'] = duration
 
-    # if moviedata reports other, that's a sign that it doesn't know what the
-    # file type is.  Just leave out the file_type key so that we fallback to
-    # the mutagen guess.
-    if file_type != "other":
+    # Return a file_type only if the duration is > 0.  Otherwise it may be a
+    # false identification (#18840).  Also, if moviedata reports other, that's
+    # a sign that it doesn't know what the file type is.  Just leave out the
+    # file_type key so that we fallback to the mutagen guess.
+    if file_type != "other" and (duration not in (0, None)):
         # Make file_type is unicode, or else database validation will fail on
         # insert!
         converted_result['file_type'] = unicode(file_type)

--- a/tv/lib/test/metadatatest.py
+++ b/tv/lib/test/metadatatest.py
@@ -645,6 +645,13 @@ class MetadataManagerTest(MiroTestCase):
         self.check_run_mutagen('foo.avi', 'video', 100, 'Foo')
         self.check_movie_data_error('foo.avi')
 
+    def test_movie_data_skips_other(self):
+        # Check that we don't run movie data if mutagen can't read the file
+        # and the extension indicates it's not a media file (#18840)
+        self.check_add_file('foo.pdf')
+        self.check_run_mutagen('foo.pdf', None, None, None)
+        self.check_movie_data_not_scheduled('foo.pdf')
+
     def test_has_drm(self):
         # check the has_drm flag
         self.check_add_file('foo.avi')


### PR DESCRIPTION
Our gstreamer movie data programs misidentify image files as video because
they can render the image.

This simplest fix is to skip moviedata if mutagen + the extension indicate
that the file is not a media file.  Also if moviedata returns 0 duration, then
assume the file is other even if movie data thinks its a video.
