### PR TITLE
Fix for logging on windows.

### DIFF
--- a/tv/windows/plat/utils.py
+++ b/tv/windows/plat/utils.py
@@ -223,9 +223,6 @@ def setup_logging(pathname, main_process=False):
                 stdouthandler = logging.StreamHandler(sys.stdout)
                 stdouthandler.setFormatter(formatter)
                 logger.addHandler(stdouthandler)
-                stderrhandler = logging.StreamHandler(sys.stderr)
-                stderrhandler.setFormatter(formatter)
-                logger.addHandler(stderrhandler)
         else:
             sys.stdout = AutoLoggingStream(logging.warn, '(from stdout) ')
             sys.stderr = AutoLoggingStream(logging.error, '(from stderr) ')


### PR DESCRIPTION
We were logging twice, once to stdout and once to stderr.  This caused really
confusing console output.
