### PR TITLE
bz18853. update device View() call for new API

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -639,7 +639,8 @@ class DeviceSyncManager(object):
                                            info.file_url),
                             view.order_by,
                             view.joins,
-                            view.limit)
+                            view.limit,
+                            view.dbinfo)
                         if not new_view.count():
                             expired.add(info)
         if max_size is not None and infos:


### PR DESCRIPTION
f867313892be7c17be858e8421aab2e7929fcb83 changed the View API to take a dbinfo
argument, but this call wasn't updated to grab that field from the view we're
duplicating.
