### PR TITLE
bz17549: Disable album view button on sharing controller for now.

### DIFF
--- a/tv/lib/frontends/widgets/sharingcontroller.py
+++ b/tv/lib/frontends/widgets/sharingcontroller.py
@@ -54,6 +54,7 @@ class SharingView(itemlistcontroller.SimpleItemListController,
         titlebar = itemlistwidgets.SharingTitlebar()
         titlebar.connect('search-changed', self._on_search_changed)
         titlebar.connect('filter-clicked', self.on_filter_clicked)
+        titlebar.hide_album_view_button()
         return titlebar
 
     def build_renderer(self):


### PR DESCRIPTION
Patch from Ben until we properly support album art on sharing.
