### PR TITLE
Bz18846: Don't kick up crash dialog in ItemInfoCache.

### DIFF
--- a/tv/osx/plat/frontends/widgets/window.py
+++ b/tv/osx/plat/frontends/widgets/window.py
@@ -65,7 +65,9 @@ class MiroResponderInterceptor(NSResponder):
         We will give the wrapper for responder a chance to handle the event,
         then pass it along to responder.
         """
+        self = super(MiroResponderInterceptor, self).init()
         self.responder = responder
+        return self
 
     def keyDown_(self, event):
         if self.sendKeyDownToWrapper_(event):
@@ -83,8 +85,8 @@ class MiroResponderInterceptor(NSResponder):
 
         # Make a new MiroResponderInterceptor whose responder is the next
         # responder down the chain.
-        next_intercepter = MiroResponderInterceptor.alloc()
-        next_intercepter.initWithResponder_(self.responder.nextResponder())
+        next_intercepter = MiroResponderInterceptor.alloc().initWithResponder_(
+                           self.responder.nextResponder())
         # Install the interceptor
         self.responder.setNextResponder_(next_intercepter)
         # Send event along
@@ -118,8 +120,8 @@ class MiroWindow(NSWindow):
     def handleKeyDown_(self, event):
         if self.handle_tab_navigation(event):
             return
-        interceptor = MiroResponderInterceptor.alloc()
-        interceptor.initWithResponder_(self.firstResponder())
+        interceptor = MiroResponderInterceptor.alloc().initWithResponder_(
+                          self.firstResponder())
         interceptor.keyDown_(event)
 
     def handle_tab_navigation(self, event):


### PR DESCRIPTION
```
bz18446: Don't kick up crash dialog in ItemInfoCache.

There are some cases where it may be possible for the cache not to have
the item info data because Miro shut down abnormally (e.g. maybe during
a hard crash or loss of power).

Just print a warning in this case to mirror what happened in production.
The crash dialog was only displayed in debug mode anyway.

Secondly, this may be a repeatable error because the recovery code did not
schedule save of the newly created item info to the backing store.  Change it
to mirror what is done for an item info add but without signaling.
```

Bonus!  Includes:

```
Cleanup MiroInterceptorResponder.

Change it to mirror the convention for Objective-C code.
```
