### PR TITLE
bz18780. force the label on ImageMenuItem (GTK)

### DIFF
--- a/tv/lib/frontends/widgets/gtk/gtkmenus.py
+++ b/tv/lib/frontends/widgets/gtk/gtkmenus.py
@@ -167,7 +167,9 @@ class MenuItem(MenuItemBase):
         Subclasses will probably want to override this.
         """
         if self.name in _STOCK_IDS:
-            return gtk.ImageMenuItem(stock_id=_STOCK_IDS[self.name])
+            mi = gtk.ImageMenuItem(stock_id=_STOCK_IDS[self.name])
+            mi.set_label(label)
+            return mi
         else:
             return gtk.MenuItem(label)
 


### PR DESCRIPTION
We were just using the stock label, which wasn't translated and didn't always
have the label we wanted.  Now we force the label after we create the menu
item.
