### PR TITLE
bz18870: disconnect TableView from TableModel when we're done with them.

### DIFF
--- a/tv/lib/frontends/widgets/gtk/tableview.py
+++ b/tv/lib/frontends/widgets/gtk/tableview.py
@@ -1157,6 +1157,16 @@ class TableView(Widget, GTKSelectionOwnerMixin, DNDHandlerMixin,
         if custom_headers:
             self._enable_custom_headers()
 
+    # FIXME: should implement set_model() and make None a special case.
+    def unset_model(self):
+        """Disconnect our model from this table view.
+
+        This should be called when you want to destroy a TableView and
+        there's a new TableView sharing its model.
+        """
+        self._widget.set_model(None)
+        self.model = None
+
     def _connect_signals(self):
         self.create_signal('row-expanded')
         self.create_signal('row-collapsed')

--- a/tv/lib/frontends/widgets/itemlistcontroller.py
+++ b/tv/lib/frontends/widgets/itemlistcontroller.py
@@ -986,6 +986,8 @@ class ItemListController(object):
         self.cancel_track_item_lists()
         self.cancel_track_playback()
         self.cancel_track_config_changes()
+        for item_view in self.all_item_views():
+            item_view.unset_model()
 
     def track_item_lists(self):
         if self._item_tracker_callbacks:

--- a/tv/osx/plat/frontends/widgets/tablemodel.py
+++ b/tv/osx/plat/frontends/widgets/tablemodel.py
@@ -356,9 +356,10 @@ class TreeTableModel(TableModelBase):
             self.forget_iter_for_item(child)
 
     def remove(self, iter):
-        self.emit('structure-will-change')
-        self.forget_iter_for_item(iter.value())
-        return TableModelBase.remove(self, iter)
+        item = iter.value()
+        rv = TableModelBase.remove(self, iter)
+        self.forget_iter_for_item(item)
+        return rv
 
     def insert_before(self, iter, *column_values):
         self.emit('structure-will-change')

--- a/tv/osx/plat/frontends/widgets/tableview.py
+++ b/tv/osx/plat/frontends/widgets/tableview.py
@@ -1283,14 +1283,21 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         self.header_height = HEADER_HEIGHT
         self.set_show_headers(True)
         self.notifications = NotificationForwarder.create(self.tableview)
-        self.model.connect_weak('row-changed', self.on_row_change)
-        self.model.connect_weak('structure-will-change',
-                self.on_model_structure_change)
+        self.model_signal_ids = [
+            self.model.connect_weak('row-changed', self.on_row_change),
+            self.model.connect_weak('structure-will-change',
+                    self.on_model_structure_change),
+        ]
         self.iters_to_update = []
         self.height_changed = self.reload_needed = False
         self._resizing = False
         if custom_headers:
             self._enable_custom_headers()
+
+    def unset_model(self):
+        for signal_id in self.model_signal_ids:
+            self.model.disconnect(signal_id)
+        self.model = None
 
     def _check_selection(self):
         """

--- a/tv/osx/plat/frontends/widgets/tableview.py
+++ b/tv/osx/plat/frontends/widgets/tableview.py
@@ -1298,6 +1298,8 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         for signal_id in self.model_signal_ids:
             self.model.disconnect(signal_id)
         self.model = None
+        self.tableview.setDataSource_(None)
+        self.data_source = None
 
     def _check_selection(self):
         """

--- a/tv/osx/plat/frontends/widgets/tableview.py
+++ b/tv/osx/plat/frontends/widgets/tableview.py
@@ -1290,6 +1290,7 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         ]
         self.iters_to_update = []
         self.height_changed = self.reload_needed = False
+        self.old_selection = None
         self._resizing = False
         if custom_headers:
             self._enable_custom_headers()
@@ -1300,19 +1301,6 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         self.model = None
         self.tableview.setDataSource_(None)
         self.data_source = None
-
-    def _check_selection(self):
-        """
-        Used by `start_bulk_change` and `on_model_structure_change` to see if
-        the selection has changed.  When the structure changes in big ways,
-        OS X doesn't always notify us.
-        """
-        try:
-            self.get_selection()
-        except errors.WidgetActionError:
-            # no more selection means we've removed the selected item
-            # (see #17823)
-            self.on_selection_changed(self.tableview)
 
     def _enable_custom_headers(self):
         self.custom_header = True
@@ -1340,9 +1328,13 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
             self.tableview.hotspot_tracker.update_hit()
 
     def on_model_structure_change(self, model):
-        self.reload_needed = True
-        self._check_selection()
+        self.will_need_reload()
         self.cancel_hotspot_track()
+
+    def will_need_reload(self):
+        if not self.reload_needed:
+            self.reload_needed = True
+            self.old_selection = [i.value() for i in self.get_selection()]
 
     def cancel_hotspot_track(self):
         if self.tableview.hotspot_tracker is not None:
@@ -1490,8 +1482,7 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         # stop our model from emitting signals, which is slow if we're
         # adding/removing/changing a bunch of rows.  Instead, just reload the
         # model afterwards.
-        self.reload_needed = True
-        self._check_selection()
+        self.will_need_reload()
         self.cancel_hotspot_track()
         self.model.freeze_signals()
 
@@ -1502,6 +1493,10 @@ class TableView(CocoaSelectionOwnerMixin, CocoaScrollbarOwnerMixin, Widget):
         size_changed = False
         if self.reload_needed:
             self.tableview.reloadData()
+            new_selection = [i.value() for i in self.get_selection()]
+            if new_selection != self.old_selection:
+                self.on_selection_changed(self.tableview)
+            self.old_selection = None
             size_changed = True
         elif self.iters_to_update:
             if self.fixed_height or not self.height_changed:


### PR DESCRIPTION
Before this was happening:
- User selects a tab, we create a table model and table view connected to
  that model.
- User moves the tab into/out of the folder
  - We re-use the table model and make a new table view
  - The old table view still would still handle the signals from the model,
    but we weren't really prepared to handle them and would throw an
    exception.

Fixed this by adding code to explicitly make a table view stop using a model.
It would be nice to support set_model() and make setting it to None a special
case, but it's not easy to do on OSX, so let's wait for this.
