### PR TITLE
bz18871.  in do_activate NameError: global name 'sender' is not defined

### DIFF
--- a/tv/osx/plat/frontends/widgets/osxmenus.py
+++ b/tv/osx/plat/frontends/widgets/osxmenus.py
@@ -534,7 +534,7 @@ class MenuBar(MenuShell):
         elif name == "PresentHalfSize":
             NSApp().delegate().present_movie('half-size')
         elif name == "ShowMain":
-            app.widgetapp.window.nswindow.makeKeyAndOrderFront_(sender)
+            app.widgetapp.window.nswindow.makeKeyAndOrderFront_(self)
 
     def _connect_to_signals(self):
         app.playback_manager.connect("will-play", self._on_playback_change)


### PR DESCRIPTION
In c2fe52ef the code got refactored a bit, and the code in question got moved
into a different function.  Since we're handling the signal before it goes out
to other handlers, what used to be the `sender` is now `self`, since the
current object is sending the signal.
