### PR TITLE
bz18882: fix unittests when mutagen returns a slightly different duratio...

### DIFF
--- a/tv/lib/test/filetagstest.py
+++ b/tv/lib/test/filetagstest.py
@@ -50,8 +50,13 @@ class FileTagsTest(MiroTestCase):
             self.assertEquals(results.pop('created_cover_art'), True)
         else:
             self.assert_('cover_art' not in results)
+        if 'duration' in expected:
+            expected_duration = expected.pop('duration')
+            result_duration = results.pop('duration')
+            self.assertClose(result_duration, expected_duration)
+
         # for the rest, we just compare the dicts
-        self.assertEquals(results, expected)
+        self.assertDictEquals(results, expected)
 
     def test_shared_cover_art(self):
         # test what happens when 2 files with coverart share the same album.

--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -525,6 +525,19 @@ class MiroTestCase(unittest.TestCase):
                 raise AssertionError("Values differ for key %r: %r -- %r" %
                         (k, dict1[k], dict2[k]))
 
+    def assertClose(self, value1, value2, tolerance=0.1):
+        """Assert that 2 values are near each other.
+
+        :param value1: value to compare
+        :param value2: value to compare
+        :param tolerance: how different the two can be
+        """
+
+        difference = float(max(value1, value2)) / float(min(value1, value2))
+        if difference > 1.0 + tolerance:
+            raise AssertionError("Difference too big: %s, %s" % (value1,
+                                                                 value2))
+
 class EventLoopTest(MiroTestCase):
     def setUp(self):
         MiroTestCase.setUp(self)

--- a/tv/lib/test/framework.py
+++ b/tv/lib/test/framework.py
@@ -533,8 +533,9 @@ class MiroTestCase(unittest.TestCase):
         :param tolerance: how different the two can be
         """
 
-        difference = float(max(value1, value2)) / float(min(value1, value2))
-        if difference > 1.0 + tolerance:
+        difference = abs(value1 - value2)
+        relative_difference = difference / max(abs(value1), abs(value2))
+        if relative_difference > tolerance:
             raise AssertionError("Difference too big: %s, %s" % (value1,
                                                                  value2))
 

--- a/tv/lib/test/storedatabasetest.py
+++ b/tv/lib/test/storedatabasetest.py
@@ -717,12 +717,7 @@ class PreallocateTest(MiroTestCase):
         disk_size = os.stat(path).st_size
         # allow some variance for the disk size, we just need to be in the
         # ballpark
-        if disk_size > preallocate_size * 1.1:
-            raise AssertionError("database size too large: %s (should be %s)"
-                                 % (disk_size, preallocate_size))
-        if disk_size < preallocate_size * 0.9:
-            raise AssertionError("database size too small: %s (should be %s)"
-                                 % (disk_size, preallocate_size))
+        self.assertClose(disk_size, preallocate_size)
 
     def test_preallocate(self):
         # test preallocating space

--- a/tv/lib/test/subprocesstest.py
+++ b/tv/lib/test/subprocesstest.py
@@ -372,7 +372,7 @@ class MutagenTest(WorkerProcessTest):
         self.runEventLoop(4.0)
         self.check_successful_result()
         self.assertEquals(self.result['file_type'], file_type)
-        self.assertEquals(self.result['duration'], duration)
+        self.assertClose(self.result['duration'], duration)
         self.assertEquals(self.result['title'], title)
         if has_cover_art:
             self.assertNotEquals(self.result['cover_art'], None)


### PR DESCRIPTION
...n.
- Use assertDictEquals in filetagstest.  This outputs better messages if the
  comparison fails.
- Added a assertClose() method to test if 2 values are near each other.
  There's a assertNearlyEqual method from UnitTest, but that one didn't do
  what we wanted.
- Use assertClose() to compare durations from mutagen.
- While we're at it, use assertClose() to test preallocation code.
