### PR TITLE
bz18886. clear icon cache when changing items

### DIFF
--- a/tv/lib/feed.py
+++ b/tv/lib/feed.py
@@ -57,13 +57,12 @@ from miro import dialogs
 from miro import download_utils
 from miro import eventloop
 from miro import feedupdate
-from miro import flashscraper
 from miro import models
 from miro import prefs
 from miro.plat import resources
 from miro import downloader
 from miro.util import (returns_unicode, returns_filename, unicodify, check_u,
-                       check_f, quote_unicode_url, escape, to_uni,
+                       check_f, quote_unicode_url, to_uni,
                        is_url, stringify, is_magnet_uri)
 from miro import fileutil
 from miro.plat.utils import filename_to_unicode, make_url_safe, unmake_url_safe
@@ -101,7 +100,6 @@ class _RateLimiter(object):
         self.last_time = time.time()
 
     def check_for_sleep(self):
-        new_time = time.time()
         elapsed = self.last_time - time.time()
         if elapsed < 0.1:
             return # don't sleep until a decent of time has passed.
@@ -239,7 +237,7 @@ def run_feedparser(html, callback, errback):
     else:
         workerprocess.send(workerprocess.FeedparserTask(html),
                            lambda msg, result: callback(result),
-                           lambda msg, error: errback(result))
+                           lambda msg, error: errback(error))
 
 # Wait X seconds before updating the feeds at startup
 INITIAL_FEED_UPDATE_DELAY = 5.0

--- a/tv/lib/frontends/widgets/gtk/layoutmanager.py
+++ b/tv/lib/frontends/widgets/gtk/layoutmanager.py
@@ -47,7 +47,7 @@ class FontCache(util.Cache):
         key = (context, description, scale_factor, bold, italic)
         return util.Cache.get(self, key)
 
-    def create_new_value(self, key):
+    def create_new_value(self, key, invalidator=None):
         (context, description, scale_factor, bold, italic) = key
         return Font(context, description, scale_factor, bold, italic)
 

--- a/tv/lib/frontends/widgets/itemlistwidgets.py
+++ b/tv/lib/frontends/widgets/itemlistwidgets.py
@@ -2257,7 +2257,9 @@ class ItemDetailsWidget(widgetset.VBox):
         self.description_label.set_text(info.description_stripped[0])
         self.set_extra_info_text(info)
         self.setup_license_button(info)
-        image = imagepool.get(info.thumbnail, self.IMAGE_SIZE)
+        image = imagepool.get(info.thumbnail, self.IMAGE_SIZE,
+                              invalidator=util.mtime_invalidator(
+                info.thumbnail))
         self.image_widget.set_image(image)
         self.set_label_widths()
         self._set_empty_mode(False)

--- a/tv/lib/frontends/widgets/itemrenderer.py
+++ b/tv/lib/frontends/widgets/itemrenderer.py
@@ -1098,7 +1098,9 @@ class ItemRendererCanvas(object):
         context.fill()
 
     def draw_thumbnail(self, context, x, y, width, height):
-        icon = imagepool.get_surface(self.thumbnail, (width, height))
+        icon = imagepool.get_surface(self.thumbnail, (width, height),
+                                     invalidator=util.mtime_invalidator(
+                self.thumbnail))
         icon_x = x + (width - icon.width) // 2
         icon_y = y + (height - icon.height) // 2
         # if our thumbnail is far enough to the left, we need to set a clip

--- a/tv/lib/frontends/widgets/style.py
+++ b/tv/lib/frontends/widgets/style.py
@@ -33,6 +33,7 @@ import logging
 import math
 
 from miro import displaytext
+from miro import util
 from miro.gtcache import gettext as _
 from miro.frontends.widgets import cellpack
 from miro.frontends.widgets import imagepool
@@ -1022,7 +1023,9 @@ class MultiRowAlbumRenderer(widgetset.InfoListRenderer):
         if album_art_path is None:
             return None
         return imagepool.get_surface(album_art_path,
-                size=(self.album_art_size, self.album_art_size))
+                size=(self.album_art_size, self.album_art_size),
+                                     invalidator=util.mtime_invalidator(
+                album_art_path))
 
     def render_album_art(self, context):
         album_art = self.make_album_art(context)

--- a/tv/lib/test/utiltest.py
+++ b/tv/lib/test/utiltest.py
@@ -1,8 +1,10 @@
 # coding=latin-1
 # The above comment is required, because it includes non-latin characters
 # as an inline string in the source, we need to have this here as per PEP 263.
+import itertools
 import os
 import tempfile
+import time
 import shutil
 import unittest
 import sys
@@ -35,6 +37,19 @@ class FakeStream:
 
     def flush(self):
         pass
+
+class MockCache(util.Cache):
+    """
+    MockCache is used to test the Cache object.  The new values are a tuple of
+    the value passed in and a counter value, incremented each time a new value
+    is made.
+    """
+    def __init__(self, size):
+        util.Cache.__init__(self, size)
+        self.value_counter = itertools.count()
+
+    def create_new_value(self, val, invalidator=None):
+        return (val, self.value_counter.next())
 
 class AutoFlushingStreamTest(unittest.TestCase):
     def setUp(self):
@@ -996,3 +1011,59 @@ class TestBackupSupportDir(MiroTestCase):
         self.assertTrue(filesize <= 1100000,
                         "Backup file too big.  filesize: %s max_size: %s" %
                         (filesize, max_size))
+
+
+class MtimeInvalidatorTestCase(MiroTestCase):
+
+    def test(self):
+        filename = os.path.join(self.tempdir, 'mtime_test')
+        file(filename, 'w').write('foo')
+        invalidator = util.mtime_invalidator(filename)
+        self.assertFalse(invalidator(None))
+        time.sleep(0.1) # might not work on Windows? Not sure what the
+                        # resolution of mtime is there.
+        file(filename, 'w').write('bar')
+        self.assertTrue(invalidator(None))
+
+class CacheTestCase(MiroTestCase):
+
+    def setUp(self):
+        MiroTestCase.setUp(self)
+        self.cache = MockCache(2)
+
+    def test_set_get(self):
+        self.cache.set(1, 1)
+        self.assertEquals(self.cache.get(1), 1)
+
+    def test_create_new_value_get(self):
+        self.assertEquals(self.cache.get(1), (1, 0))
+        self.assertEquals(self.cache.get(3), (3, 1))
+
+    def test_remove(self):
+        self.cache.set(1, 1)
+        self.cache.remove(1)
+        self.assertFalse(1 in self.cache.keys())
+
+    def test_lru(self):
+        self.cache.get(1)
+        self.cache.get(2)
+        self.cache.get(3)
+        # 1 has expired out
+        self.assertEquals(set(self.cache.keys()), set((2, 3)))
+
+    def test_invalidator_set(self):
+        def invalidator(key):
+            return True
+        self.cache.set(1, 1, invalidator=invalidator)
+        # previous value is now invalid, get a new one
+        self.assertEquals(self.cache.get(1), (1, 0))
+
+    def test_invalidator_get(self):
+        def invalidator(key):
+            return True
+        self.assertEquals(self.cache.get(1, invalidator=invalidator),
+                          (1, 0))
+        # previous value was invalid, get a new one
+        self.assertEquals(self.cache.get(1, invalidator=invalidator),
+                          (1, 1))
+

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -1080,27 +1080,54 @@ class DebuggingTimer:
     def log_total_time(self):
         logging.timing("total time: %0.3f", clock() - self.start_time)
 
+def mtime_invalidator(path):
+    """
+    Returns a function which returns True if the mtime of path is greater than
+    it was when this function was initially called.  Useful as an invalidator
+    for Cache.
+    """
+    path = os.path.abspath(path)
+    mtime = os.stat(path).st_mtime
+    def invalidator(key):
+        return os.stat(path).st_mtime > mtime
+    return invalidator
+
 class Cache(object):
     def __init__(self, size):
         self.size = size
         self.dict = {}
         self.counter = itertools.count()
         self.access_times = {}
+        self.invalidators = {}
 
-    def get(self, key):
+    def get(self, key, invalidator=None):
         if key in self.dict:
-            self.access_times[key] = self.counter.next()
-            return self.dict[key]
-        else:
-            value = self.create_new_value(key)
-            self.set(key, value)
-            return value
+            existing_invalidator = self.invalidators[key]
+            if (existing_invalidator is None or
+                not existing_invalidator(key)):
+                self.access_times[key] = self.counter.next()
+                return self.dict[key]
 
-    def set(self, key, value):
+        value = self.create_new_value(key, invalidator=invalidator)
+        self.set(key, value, invalidator=invalidator)
+        return value
+
+    def set(self, key, value, invalidator=None):
         if len(self.dict) == self.size:
             self.shrink_size()
         self.access_times[key] = self.counter.next()
         self.dict[key] = value
+        self.invalidators[key] = invalidator
+
+    def remove(self, key):
+        if key in self.dict:
+            del self.dict[key]
+            del self.access_times[key]
+        if key in self.invalidators:
+            del self.invalidators[key]
+
+    def keys(self):
+        return self.dict.iterkeys()
 
     def shrink_size(self):
         # shrink by LRU
@@ -1108,14 +1135,16 @@ class Cache(object):
         to_sort.sort(key=lambda m: m[1])
         new_dict = {}
         new_access_times = {}
+        new_invalidators = {}
         latest_times = to_sort[len(self.dict) // 2:]
         for (key, time) in latest_times:
             new_dict[key] = self.dict[key]
+            new_invalidators[key] = self.invalidators[key]
             new_access_times[key] = time
         self.dict = new_dict
         self.access_times = new_access_times
 
-    def create_new_value(self, val):
+    def create_new_value(self, val, invalidator=None):
         raise NotImplementedError()
 
 def all_subclasses(cls):


### PR DESCRIPTION
YouTube video names are pretty common (3.*.jpg), so when we weren't clearing
the cache when changing the underlying thumbnail, the frontend was getting
confused.
