### PR TITLE
bz18897: avoid decoding errors when printing our path.

### DIFF
--- a/tv/lib/metadata.py
+++ b/tv/lib/metadata.py
@@ -626,7 +626,7 @@ class _EchonestProcessor(_MetadataProcessor):
         self._codegen_finished()
 
     def _codegen_errback(self, path, error):
-        logging.warn("Error running echonest codegen for %s (%s)" %
+        logging.warn("Error running echonest codegen for %r (%s)" %
                      (path, error))
         self.emit('task-error', path, error)
         del self._metadata_for_path[path]


### PR DESCRIPTION
I'm pretty sure we should always be using %r to format paths, since it works
for both unicode, bytestrings, and even if there's an invalid character in
there.
