### PR TITLE
bz18915: fix crash in GTK custom slider code

### DIFF
--- a/tv/lib/frontends/widgets/gtk/customcontrols.py
+++ b/tv/lib/frontends/widgets/gtk/customcontrols.py
@@ -222,7 +222,7 @@ class CustomScaleMixin(CustomControlMixin):
             self.set_value(self.start_value)
 
     def do_button_release_event(self, event):
-        if event.button != self.drag_info.button:
+        if self.drag_info is None or event.button != self.drag_info.button:
             return
         self.drag_info = None
         if (self.is_continuous and


### PR DESCRIPTION
self.drag_info will be None if the user has 2 buttons pressed down at once.
Then when the first button release happens we set set drag_info to None and
emit our signals.  When the second button is released we should just ignore
it.
