### PR TITLE
bz18918: Use EnvironmentError to catch shutil.Error.

### DIFF
--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -378,7 +378,7 @@ def copy_subtitle_file(sub_path, video_path):
             if os.path.exists(dest_path):
                 os.remove(dest_path)
             shutil.copyfile(sub_path, dest_path)
-        except (OSError, IOError):
+        except EnvironmentError:
             logging.exception('unable to remove existing subtitle file '
                               'or copy subtitle file')
             dest_path = ''


### PR DESCRIPTION
Catch hopefully all possible errors when trying shutil.copyfile() fails.
