### PR TITLE
bz18930: Guard against get_total_playback_time() use.

### DIFF
--- a/tv/lib/frontends/widgets/gtk/audio.py
+++ b/tv/lib/frontends/widgets/gtk/audio.py
@@ -49,10 +49,6 @@ class AudioPlayer(player.GTKPlayer):
     def play(self):
         self.renderer.play()
 
-    def play_from_time(self, resume_time=0):
-        self.seek_to_time(resume_time)
-        self.play()
-
     def pause(self):
         self.renderer.pause()
 

--- a/tv/lib/frontends/widgets/gtk/video.py
+++ b/tv/lib/frontends/widgets/gtk/video.py
@@ -551,13 +551,6 @@ class VideoPlayer(player.GTKPlayer, VBox):
         # do this to trigger the overlay showing up for a smidge
         self.on_mouse_motion(None)
 
-    def play_from_time(self, resume_time=0):
-        # Note: This overrides player.Player's version of play_from_time, but
-        # this one seeks directly rather than fiddling with
-        # total_playback_time.
-        self.seek_to_time(resume_time)
-        self.play()
-
     def pause(self):
         self.renderer.pause()
 

--- a/tv/lib/frontends/widgets/playback.py
+++ b/tv/lib/frontends/widgets/playback.py
@@ -270,7 +270,11 @@ class PlaybackManager (signals.SignalEmitter):
         if self.player_playing():
             elapsed = self.player.get_elapsed_playback_time()
             total = self.player.get_total_playback_time()
-            self.emit('playback-did-progress', elapsed, total)
+            if elapsed is not None and total is not None:
+                self.emit('playback-did-progress', elapsed, total)
+            else:
+                logging.warning('notify_update: elapsed = %s total = %s',
+                                elapsed, total)
 
     def on_display_removed(self, display):
         if not self.removing_video_display:
@@ -282,6 +286,9 @@ class PlaybackManager (signals.SignalEmitter):
             logging.warn("no self.player in play(). race condition?")
             return
         duration = self.player.get_total_playback_time()
+        if duration is None or duration <= 0:
+            logging.warning('duration is %s', duration)
+            return
         self.emit('will-play', duration)
         resume_time = self.playlist.currently_playing.resume_time
         if start_at > 0:
@@ -454,6 +461,9 @@ class PlaybackManager (signals.SignalEmitter):
         if resume_time == -1:
             resume_time = self.player.get_elapsed_playback_time()
             duration = self.player.get_total_playback_time()
+            if duration is None:
+                logging.warning('update_current_resume_time: duration is None')
+                return
             # if we are 95% of the way into the movie and less than 30
             # seconds before the end, don't save resume time (#11956)
             if resume_time > min(duration * 0.95, duration - 30):

--- a/tv/osx/plat/frontends/widgets/quicktime.py
+++ b/tv/osx/plat/frontends/widgets/quicktime.py
@@ -374,18 +374,6 @@ class Player(player.Player):
         qttime = self.movie.duration()
         return qttimeutils.qttime2secs(qttime)
 
-    def skip_forward(self):
-        current = self.get_elapsed_playback_time()
-        duration = self.get_total_playback_time()
-        pos = min(duration, current + 30.0)
-        self.seek_to(pos / duration)
-
-    def skip_backward(self):
-        current = self.get_elapsed_playback_time()
-        duration = self.get_total_playback_time()
-        pos = max(0, current - 15.0)
-        self.seek_to(pos / duration)
-
     def seek_to(self, position):
         if not self.movie:
             return
@@ -395,10 +383,6 @@ class Player(player.Player):
         else:
             qttime.timeValue = qttime.timeValue * position
         self.movie.setCurrentTime_(qttime)
-
-    def play_from_time(self, resume_time=0):
-        self.seek_to(resume_time / self.get_total_playback_time())
-        self.play()
 
     def set_playback_rate(self, rate):
         if self.movie:


### PR DESCRIPTION
This method may return None, so guard against its usage in arithmetic
operations.  In addition it may theoretically return 0.  Make sure
we never use such a value in the denominator.
