### PR TITLE
bz18902: Make sure that embedding window is still valid on destructor pa...

### DIFF
--- a/tv/windows/plat/frontends/widgets/embeddingwidget.py
+++ b/tv/windows/plat/frontends/widgets/embeddingwidget.py
@@ -98,10 +98,15 @@ class EmbeddingWidget(gtk.DrawingArea):
             self.embedding_window.reposition(*self._get_window_area())
 
     def destroy(self):
+        # NB: here we call the embedding_window's destroy() method after
+        # the DrawingArea's destroy() because apparently DrawingArea's
+        # destroy() can invoke do_unrealize(), which detaches the embedding
+        # window.  Therefore only free the embedding_window after we
+        # are adament that nobody can be using it.
+        gtk.DrawingArea.destroy(self)
         self.embedding_window.destroy()
         self.embedding_window = None
         # let DrawingArea take care of the rest
-        gtk.DrawingArea.destroy(self)
         _live_widgets.discard(self)
 
     # EmbeddingWindow callback functions.  Child classes can overide these if


### PR DESCRIPTION
...th.

Make sure the embedding window is still around when calling destroy
as the destructor path may stil make use of it.
