### PR TITLE
bz18929. don't convert items we can't handle

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -729,7 +729,8 @@ class DeviceSyncManager(object):
         items_for_converter = {}
         for info in items:
             converter = self.conversion_for_info(info)
-            items_for_converter.setdefault(converter, set()).add(info)
+            if converter is not None:
+                items_for_converter.setdefault(converter, set()).add(info)
         if 'copy' in items_for_converter:
             items = items_for_converter.pop('copy')
             count += len(items)


### PR DESCRIPTION
`conversion_for_info()` returns None for items it can't handle (they don't have
a path, they aren't media), and we shouldn't try to do anything with them.
