### PR TITLE
don't depend on time.sleep() changing the mtime

### DIFF
--- a/tv/lib/test/utiltest.py
+++ b/tv/lib/test/utiltest.py
@@ -1020,9 +1020,9 @@ class MtimeInvalidatorTestCase(MiroTestCase):
         file(filename, 'w').write('foo')
         invalidator = util.mtime_invalidator(filename)
         self.assertFalse(invalidator(None))
-        time.sleep(0.1) # might not work on Windows? Not sure what the
-                        # resolution of mtime is there.
-        file(filename, 'w').write('bar')
+        mtime = os.stat(filename).st_mtime
+        # pretend the file was modified in the future
+        os.utime(filename, (mtime + 10, mtime + 10))
         self.assertTrue(invalidator(None))
 
 class CacheTestCase(MiroTestCase):


### PR DESCRIPTION
This wasn't working on the build box, apparently because the resolution was
only 1 second.  Switch to using `os.utime()` to set the modification time into
the future instead.
