### PR TITLE
bz18957. avoid overflow in pango.PIXELS

### DIFF
--- a/tv/lib/frontends/widgets/gtk/layoutmanager.py
+++ b/tv/lib/frontends/widgets/gtk/layoutmanager.py
@@ -145,8 +145,10 @@ class Font(object):
 
     def line_height(self):
         metrics = self.get_font_metrics()
-        # the +1: some glyphs can be slightly taller than ascent+descent (#17329)
-        return pango.PIXELS(metrics.get_ascent() + metrics.get_descent()) + 1
+        # the +1: some glyphs can be slightly taller than ascent+descent
+        # (#17329)
+        return (pango.PIXELS(metrics.get_ascent()) +
+                pango.PIXELS(metrics.get_descent()) + 1)
 
 class TextBox(object):
     def __init__(self, context, font, color, shadow):


### PR DESCRIPTION
A user experienced a crash where the result of ascent() + descent() wouldn't
fit in an int.  I can't reproduce it, but this should avoid the issue.
