### PR TITLE
bz18965. OSError in mtime_invalidator

### DIFF
--- a/tv/lib/test/utiltest.py
+++ b/tv/lib/test/utiltest.py
@@ -1015,14 +1015,34 @@ class TestBackupSupportDir(MiroTestCase):
 
 class MtimeInvalidatorTestCase(MiroTestCase):
 
-    def test(self):
+    def test_valid(self):
         filename = os.path.join(self.tempdir, 'mtime_test')
         file(filename, 'w').write('foo')
         invalidator = util.mtime_invalidator(filename)
         self.assertFalse(invalidator(None))
+
+    def test_invalid(self):
+        filename = os.path.join(self.tempdir, 'mtime_test_future')
+        file(filename, 'w').write('foo')
+        invalidator = util.mtime_invalidator(filename)
         mtime = os.stat(filename).st_mtime
         # pretend the file was modified in the future
         os.utime(filename, (mtime + 10, mtime + 10))
+        self.assertTrue(invalidator(None))
+
+    def test_doesnotexist(self):
+        filename = os.path.join(self.tempdir,
+                                'mtime_test_doesnotexist')
+        invalidator = util.mtime_invalidator(filename)
+        self.assertTrue(invalidator(None))
+
+    def test_disappears(self):
+        filename = os.path.join(self.tempdir,
+                                'mtime_test_disappears')
+        file(filename, 'w').write('foo')
+        invalidator = util.mtime_invalidator(filename)
+        self.assertFalse(invalidator(None))
+        os.unlink(filename)
         self.assertTrue(invalidator(None))
 
 class CacheTestCase(MiroTestCase):

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -1087,9 +1087,20 @@ def mtime_invalidator(path):
     for Cache.
     """
     path = os.path.abspath(path)
-    mtime = os.stat(path).st_mtime
+    try:
+        mtime = os.stat(path).st_mtime
+    except EnvironmentError:
+        # if the file doesn't exist or has a problem when we start, the cache
+        # will always be invalid
+        return lambda x: True
+
     def invalidator(key):
-        return os.stat(path).st_mtime > mtime
+        try:
+            return os.stat(path).st_mtime > mtime
+        except EnvironmentError:
+            # if the file disappears, the cache is also invalid
+            return True
+
     return invalidator
 
 class Cache(object):


### PR DESCRIPTION
If the file does not exist, or disappears, the cache should be invalidated.
