### PR TITLE
bz18974: Always emit will-play.

### DIFF
--- a/tv/lib/frontends/widgets/playback.py
+++ b/tv/lib/frontends/widgets/playback.py
@@ -288,7 +288,6 @@ class PlaybackManager (signals.SignalEmitter):
         duration = self.player.get_total_playback_time()
         if duration is None or duration <= 0:
             logging.warning('duration is %s', duration)
-            return
         self.emit('will-play', duration)
         resume_time = self.playlist.currently_playing.resume_time
         if start_at > 0:

--- a/tv/lib/frontends/widgets/videobox.py
+++ b/tv/lib/frontends/widgets/videobox.py
@@ -288,6 +288,8 @@ class ProgressTimeRemaining(widgetset.CustomButton):
         self.queue_redraw()
 
     def set_duration(self, duration):
+        if duration is None:
+            duration = 0
         self.duration = duration
         self.queue_redraw()
 
@@ -342,8 +344,11 @@ class ProgressSlider(widgetset.CustomSlider):
 
     def handle_play(self, obj, duration):
         self.playing = True
-        # This makes it so that the mouswheel scrolls exactly 5 seconds
-        step_size = 5.0 / duration
+        # This makes it so that the mousewheel scrolls exactly 5 seconds
+        if duration is None or duration < 5:
+            step_size = 1
+        else:
+            step_size = 5.0 / duration
         self.set_increments(step_size, step_size, step_size)
         self.enable()
 


### PR DESCRIPTION
Many components depend on it so emit even if the duration is None.
Having said that make the receivers of this signal check that duration
is vaild before using.
