### PR TITLE
bz18992: fix layout of dialogs on OSX (specifically item-edit)

### DIFF
--- a/tv/lib/frontends/widgets/itemedit.py
+++ b/tv/lib/frontends/widgets/itemedit.py
@@ -565,15 +565,10 @@ class VideoPanel(DialogPanel):
                 (u'podcast', _("Podcast")),
             ]),
         ]
-        content = widgetset.VBox()
+        self.vbox = widgetset.VBox()
         for field in self.fields:
             field.set_label_width(120)
-            content.pack_start(field.get_box(), padding=5)
-        # XXX - hack: OS X is cutting off the right side of the box in single
-        # selection mode; this seems like a bug in layout. padding the right
-        # side causes only padding to be cut off.
-        # XXX - this padding fixes 17065. 17065 is the same layout issue?
-        self.vbox = widgetutil.pad(content, right=15)
+            self.vbox.pack_start(field.get_box(), padding=5)
 
 class ToggleButtonBackground(widgetset.Background):
     """Gradiated background for an individual ToggleButton."""
@@ -757,6 +752,17 @@ class ItemEditDialog(widgetset.Dialog):
         self.panels[name] = content
         self.toggler.add_option(name, label)
 
+    def set_width_from_panels(self):
+        """Set the min-width for our panels.
+
+        We set the min-width to the width of the biggest panel, to avoid
+        things moving too much when the user switches between them
+        """
+        max_width = -1
+        for panel in self.panels.values():
+            max_width = max(max_width, panel.vbox.get_size_request()[0])
+        self.content_panel.set_size_request(max_width, -1)
+
     def on_choose_panel(self, _toggler, name):
         self.content_panel.set(self.panels[name].vbox)
 
@@ -768,6 +774,7 @@ class ItemEditDialog(widgetset.Dialog):
         self._add_panel(_("General"), 'general', GeneralPanel(self.items))
         self._add_panel(_("Video"), 'video', VideoPanel(self.items))
         self._pack_bottom()
+        self.set_width_from_panels()
         self.toggler.choose('general')
         self.content_panel.set(self.panels['general'].vbox)
         return self.vbox

--- a/tv/osx/plat/frontends/widgets/base.py
+++ b/tv/osx/plat/frontends/widgets/base.py
@@ -106,6 +106,18 @@ class Widget(signals.SignalEmitter):
         """
         raise NotImplementedError()
 
+    def _debug_size_request(self, nesting_level=0):
+        """Debug size request calculations.
+
+        This method recursively prints out the size request for each widget.
+        """
+        request = self.calc_size_request()
+        width = int(request[0])
+        height = int(request[1])
+        indent = '    ' * nesting_level
+        me = str(self.__class__).split('.')[-1]
+        print '%s%s: %sx%s' % (indent, me, width, height)
+
     def place(self, rect, containing_view):
         """Place this widget on a view.  """
         if self.viewport is None:
@@ -262,6 +274,11 @@ class Container(Widget):
     def place_children(self):
         """Layout our child widgets.  Must be implemented by subclasses."""
         raise NotImplementedError()
+
+    def _debug_size_request(self, nesting_level=0):
+        for child in self.children:
+            child._debug_size_request(nesting_level+1)
+        Widget._debug_size_request(self, nesting_level)
 
 class Bin(Container):
     """Container that only has one child widget."""

--- a/tv/osx/plat/frontends/widgets/window.py
+++ b/tv/osx/plat/frontends/widgets/window.py
@@ -445,6 +445,9 @@ class Dialog(DialogBase):
         content_rect.size = NSSize(width, height)
         new_frame = self.window.frameRectForContentRect_(content_rect)
         self.window.setFrame_display_(new_frame, NO)
+        # Need to call place() again, since our window has changed size
+        contentView = self.window.contentView()
+        self.content_widget.place(contentView.frame(), contentView)
 
     def run(self):
         self.window = self.build_window()


### PR DESCRIPTION
Added a function to help debug layout code.  It recursively prints out the
size request for a given widget and its descendents.

Fixed things 2 ways:

 1) If the size request for our content widget changes, then we re-place it.
 This is needed because the window frame size changes.

 2) Set size request for the item edit content panel so that it fits the
 biggest panel we have.  This makes the dialog change less when things switch.
