### PR TITLE
bz19008. timeout MutagenTask (if supported)

### DIFF
--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -35,6 +35,7 @@ any other Miro modules.
 
 from hashlib import sha1 as sha
 from StringIO import StringIO
+import contextlib
 import itertools
 import logging
 import os
@@ -43,6 +44,7 @@ import re
 import shutil
 import socket
 import string
+import signal
 import subprocess
 import sys
 import tempfile
@@ -1348,3 +1350,20 @@ def next_free_directory(name):
         candidate = candidates.next()
         if not os.path.exists(candidate):
             return candidate
+
+@contextlib.contextmanager
+def alarm(timeout, set_signal=True):
+    def alarm_handler(signum, frame):
+        raise IOError('timeout after %i seconds' % timeout)
+    if set_signal:
+        set_signal = hasattr(signal, 'SIGALRM')
+    if set_signal:
+        signal.signal(signal.SIGALRM, alarm_handler)
+        signal.alarm(timeout)
+    yield set_signal
+    if set_signal:
+        signal.alarm(0)
+
+def supports_alarm():
+    with alarm(1) as result:
+        return result

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -1365,5 +1365,4 @@ def alarm(timeout, set_signal=True):
         signal.alarm(0)
 
 def supports_alarm():
-    with alarm(1) as result:
-        return result
+    return hasattr(signal, 'SIGALRM')


### PR DESCRIPTION
When given a broken file, Mutagen can hang in a busyloop reading the file.  If
supported by the operating system, we can use signals (SIGALRM in particular)
to kill the busyloop.

I'm not convinced that this is the ideal way to do it, but that'll get covered
by peer review.
