### PR TITLE
bz19040. some feeds break feedparser's image handling

### DIFF
--- a/tv/lib/feed.py
+++ b/tv/lib/feed.py
@@ -1258,11 +1258,22 @@ class RSSFeedImplBase(ThrottledUpdateFeedImpl):
 
         if channel_title != None and self._allow_feed_to_override_title():
             self.title = channel_title
-        if (parsed.feed.has_key('image') and
-                parsed.feed.image.has_key('url') and
-                self._allow_feed_to_override_thumbnail()):
-            self.thumbURL = parsed.feed.image.url
-            self.ufeed.icon_cache.request_update(is_vital=True)
+        if parsed.feed.has_key('image'):
+            image = parsed.feed['image']
+            image_url = None
+            if isinstance(image, dict):
+                if 'url' in image:
+                    image_url = image['url']
+                elif 'href' in image:
+                    image_url = image['href']
+            elif isinstance(image, basestring):
+                image_url = image
+            else:
+                logging.warn('strange image value from %r: %r',
+                             self.url, image)
+            if image_url and self._allow_feed_to_override_thumbnail():
+                self.thumbURL = image_url
+                self.ufeed.icon_cache.request_update(is_vital=True)
 
         items_byid = {}
         items_byURLTitle = {}


### PR DESCRIPTION
I didn't actually see this with my version of Feedparser (it's returning a
dictionary with an 'href' key instead), but I can visualize it returning a
Unicode string given some feed.  This code tries to be a bit more careful about
checking the keys (and whether it's looking at a dictionary at all) before
overriding the thumbnail.
