### PR TITLE
bz19071: better debugging to figure out this problem.

### DIFF
--- a/tv/lib/subprocessmanager.py
+++ b/tv/lib/subprocessmanager.py
@@ -463,8 +463,10 @@ class SubprocessManager(object):
             # So if the self.thread attribute is None then it means we are done
             # and so things are all good.
             if self.thread is not None and thread.quit_type != thread.QUIT_NORMAL:
-                app.controller.failed_soft('handling subprocess',
-                        '_on_thread_quit called by an old thread')
+                msg = ('_on_thread_quit called by an old thread '
+                        'self.thread: %s thread: %s quit_type: %s' %
+                        (self.thread.name, thread.name, thread.quit_type))
+                app.controller.failed_soft('handling subprocess', msg)
             return
 
         if (self.thread.quit_type == self.thread.QUIT_NORMAL and

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -603,7 +603,7 @@ def stringify(stringobj, handleerror="xmlcharrefreplace"):
         return stringobj.encode("ascii", handleerror)
     if isinstance(stringobj, str):
         # make sure bytestrings are ASCII
-         return stringobj.encode('string_escape')
+         return stringobj.decode('ascii', 'replace')
     else:
         # convert objects to strings, then ensure they are ASCII
         return stringify(str(stringobj))


### PR DESCRIPTION
This change definitely won't fix the bug, but it does help improve logging in
2 ways:
- Added extra info when we call failed_soft()
- Fix for stringify(), which is called by crashreporter so that it doesn't
  escape newlines.  Otherwise reading the log reports is pretty miserable.

I've tested this code by provoking the crash and it seems okay.
