### PR TITLE
Fixed stringify() and its unittest.

### DIFF
--- a/tv/lib/test/utiltest.py
+++ b/tv/lib/test/utiltest.py
@@ -213,10 +213,10 @@ class UtilTest(unittest.TestCase):
             ( u"abc\xe4", "replace", "abc?"),
             # test that bytestrings are converted to plain ASCII
             ( "abc", None, "abc"),
-            ( "abc\xe4", None, "abc\\xe4"),
+            ( "abc\xe4", None, "abc?"),
             # test that objects are converted to plain ASCII
             ( GoodStringObject(), None, "abc"),
-            ( BadStringObject(), None, "abc\\xe4"),
+            ( BadStringObject(), None, "abc?"),
             ]:
 
             if h == None:

--- a/tv/lib/util.py
+++ b/tv/lib/util.py
@@ -603,7 +603,8 @@ def stringify(stringobj, handleerror="xmlcharrefreplace"):
         return stringobj.encode("ascii", handleerror)
     if isinstance(stringobj, str):
         # make sure bytestrings are ASCII
-         return stringobj.decode('ascii', 'replace')
+         return stringobj.decode('ascii', 'replace').encode('ascii',
+                                                            'replace')
     else:
         # convert objects to strings, then ensure they are ASCII
         return stringify(str(stringobj))


### PR DESCRIPTION
My recent change to stringify() made it return unicode objects, which is
definitely wrong.  Added a call to encode afterwards to fix this.  Use the
replace error handler both ways since only that and ignore work for both
decoding and encoding.

Fixed the unittest so it passes.
