### PR TITLE
bz19017: Dispose of our thumbnail pipeline to avoid memory leaks

### DIFF
--- a/tv/lib/frontends/widgets/gst/gst_extractor.py
+++ b/tv/lib/frontends/widgets/gst/gst_extractor.py
@@ -294,6 +294,9 @@ class Extractor:
                         pad.remove_buffer_probe(self.buffer_probes[name])
                         del self.buffer_probes[name]
             self.pipeline = None
+        if self.thumbnail_pipeline is not None:
+            self.thumbnail_pipeline.set_state(gst.STATE_NULL)
+            self.thumbnail_pipeline = None
 
         if self.bus is not None:
             self.bus.disconnect(self.watch_id)


### PR DESCRIPTION
Before when I put 200 or so videos through movie data miro_helper.exe would
use over 500 megs of virtual memory.  Now it's around 70-80megs.

This actually only fixes part of #19017, but I think it's an important one.
