### PR TITLE
bz19032: metadata fixes for items marked as deleted

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3791,3 +3791,12 @@ def upgrade177(cursor):
     # drop the current_processor column
     cursor.execute("DROP INDEX metadata_processor")
     remove_column(cursor, 'metadata_status', ['current_processor'])
+
+def upgrade178(cursor):
+    """Remove metadata for items flaged as deleted."""
+    cursor.execute("DELETE FROM metadata WHERE status_id IN "
+                   "(SELECT ms.id FROM metadata_status ms "
+                   "JOIN item on ms.path = item.filename "
+                   "WHERE item.deleted)")
+    cursor.execute("DELETE FROM metadata_status WHERE path IN "
+                   "(SELECT filename FROM item WHERE item.deleted)")

--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -461,6 +461,7 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
         self.setup_common()
         self.setup_links()
         if (self.filename is not None and
+            not self.deleted and
             not app.local_metadata_manager.path_in_system(self.filename)):
             logging.warn("Path for item not in MetadataManager (%s).  "
                          "Adding it now." % (self.filename))
@@ -2232,7 +2233,11 @@ class FileItem(Item):
     def make_undeleted(self):
         self.deleted = False
         self.signal_change()
-        app.local_metadata_manager.add_file(self.filename)
+        if not app.local_metadata_manager.path_in_system(self.filename):
+            app.local_metadata_manager.add_file(self.filename)
+        else:
+            logging.warn("Item.make_undeleted: path exists in "
+                         "MetadataManager (%r)" % self.filename)
 
     def delete_files(self):
         if self.has_parent():

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -879,7 +879,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 177
+VERSION = 178
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,


### PR DESCRIPTION
If an item is marked as deleted then we delete the metadata entries for it,
however there were 2 bugs with that.

1) The next time we called setup_restore(), we would re-create the metadata
entries.

2) For items deleted with previous versions of miro, our upgrade code would
make metadata entries for it.

Fixed those 2 bugs and also added code to detect this problem and log a
warning instead of crashing.
