### PR TITLE
Changes to the title column of the item table.

### DIFF
--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -998,6 +998,7 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
     def update_from_metadata(self, metadata_dict):
         """Update our attributes from a metadata dictionary."""
         # change the name of title to be "metadata_title"
+        metadata_dict = metadata_dict.copy()
         if 'title' in metadata_dict:
             metadata_dict['metadata_title'] = metadata_dict.pop('title')
         self._bulk_update_db_values(metadata_dict)

--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -999,7 +999,7 @@ class Item(DDBObject, iconcache.IconCacheOwnerMixin):
         """Update our attributes from a metadata dictionary."""
         # change the name of title to be "metadata_title"
         if 'title' in metadata_dict:
-            metadata_dict['metadata_title'] = metadata_dict['title']
+            metadata_dict['metadata_title'] = metadata_dict.pop('title')
         self._bulk_update_db_values(metadata_dict)
         self.calc_title()
 

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -430,6 +430,7 @@ class ItemSchema(MultiClassObjectSchema):
 
     fields = DDBObjectSchema.fields + [
         ('is_file_item', SchemaBool()),
+        ('title', SchemaString(noneOk=True)),
         ('feed_id', SchemaInt(noneOk=True)),
         ('downloader_id', SchemaInt(noneOk=True)),
         ('parent_id', SchemaInt(noneOk=True)),
@@ -475,7 +476,6 @@ class ItemSchema(MultiClassObjectSchema):
         ('skip_count', SchemaInt()),
         # metadata:
         ('cover_art', SchemaFilename(noneOk=True)),
-        ('title', SchemaString(noneOk=True)),
         ('description', SchemaString(noneOk=True)),
         ('album', SchemaString(noneOk=True)),
         ('album_artist', SchemaString(noneOk=True)),
@@ -493,6 +493,7 @@ class ItemSchema(MultiClassObjectSchema):
         ('season_number', SchemaInt(noneOk=True)),
         ('kind', SchemaString(noneOk=True)),
         ('net_lookup_enabled', SchemaBool()),
+        ('metadata_title', SchemaString(noneOk=True)),
     ]
 
     indexes = (
@@ -879,7 +880,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 178
+VERSION = 179
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/test/itemtest.py
+++ b/tv/lib/test/itemtest.py
@@ -249,7 +249,7 @@ class ItemSearchTest(MiroTestCase):
                 feed_id=self.feed.id)
 
     def test_matches_search(self):
-        self.item1.entry_title = u"miro is cool"
+        self.item1.title = u"miro is cool"
         self.item1.signal_change()
         self.assertEquals(self.item1.matches_search('miro'), True)
         self.assertEquals(self.item1.matches_search('iro'), True)
@@ -412,9 +412,10 @@ class ItemMetadataTest(MiroTestCase):
             if item.filename in new_metadata:
                 md = new_metadata[item.filename]
                 self.assertEquals(item.album, md['album'])
+                self.assertEquals(item.metadata_title, md['title'])
                 self.assertEquals(item.title, md['title'])
                 self.assertEquals(item.duration, md['duration'])
             else:
                 self.assertEquals(item.album, None)
-                self.assertEquals(item.title, None)
+                self.assertEquals(item.metadata_title, None)
                 self.assertEquals(item.duration, None)

--- a/tv/lib/test/messagetest.py
+++ b/tv/lib/test/messagetest.py
@@ -458,8 +458,7 @@ class FeedItemTrackTest(TrackerTest):
         self.check_info_list(message.items, self.items)
 
     def test_update(self):
-        self.items[0].entry_title = u'new name'
-        self.items[0].signal_change()
+        self.items[0].set_rating(1)
         self.runUrgentCalls()
         self.assertEquals(len(self.test_handler.messages), 2)
         self.check_changed_message(1, changed=[self.items[0]])
@@ -490,8 +489,7 @@ class FeedItemTrackTest(TrackerTest):
     def test_stop(self):
         messages.StopTrackingItems('feed', self.feed.id).send_to_backend()
         self.runUrgentCalls()
-        self.items[0].entry_title = u'new name'
-        self.items[0].signal_change()
+        self.items[0].set_rating(0)
         self.items[1].remove()
         self.make_item(u'http://example.com/4')
         self.runUrgentCalls()
@@ -551,8 +549,7 @@ class PlaylistItemTrackTest(TrackerTest):
         self.check_info_list(message.items, self.items)
 
     def test_update(self):
-        self.items[0].entry_title = u'new name'
-        self.items[0].signal_change()
+        self.items[0].set_rating(0)
         self.runUrgentCalls()
         self.assertEquals(len(self.test_handler.messages), 2)
         self.check_changed_message(1, changed=[self.items[0]])
@@ -575,8 +572,7 @@ class PlaylistItemTrackTest(TrackerTest):
         messages.StopTrackingItems(
             'playlist', self.playlist.id).send_to_backend()
         self.runUrgentCalls()
-        self.items[0].entry_title = u'new name'
-        self.items[0].signal_change()
+        self.items[0].set_rating(0)
         self.items[1].remove()
         self.make_item(u'http://example.com/4')
         self.runUrgentCalls()

--- a/tv/lib/test/searchtest.py
+++ b/tv/lib/test/searchtest.py
@@ -129,7 +129,7 @@ class ItemSearcherTest(MiroTestCase):
         self.check_empty_result('miro')
 
     def test_update(self):
-        self.item1.entry_title = u'my new title'
+        self.item1.title = u'my new title'
         self.item1.signal_change()
         self.searcher.update_item(self.make_info(self.item1))
         self.check_search_results('my', self.item1, self.item2)


### PR DESCRIPTION
Before title tracked the title that we got from metadata (file tags, echonest,
etc).  Now that's stored in metadata_title, and title is the computed value of
title (what get_title() used to return).

This is needed if we are going to implement frontend item list using SQL
queries, since if the user sorts by title, we need this for the ORDER BY
clause.

I wrote this while working on a private branch to implement the plan in FrontendDataOverhaul.  I was thinking that maybe it would be a good idea to commit changes like this to master that are self-contained DB schema changes.  I think it might make merging less painful when I'm done with everything.

I could see an argument to not checking this in until I was done with all my work for FrontendDataOverhaul.  If you want to make an argument for that, then I could wait on merging.
