### PR TITLE
bz19145. httpclient errors aren't info hashes

### DIFF
--- a/tv/lib/flashscraper.py
+++ b/tv/lib/flashscraper.py
@@ -292,7 +292,7 @@ def _scrape_vimeo_video_url(url, callback, countdown=10):
         httpclient.grab_url(
             url,
             lambda x: _scrape_vimeo_download_callback(x, callback),
-            lambda x: _scrape_vimeo_download_errback(x, callback),
+            lambda x: _scrape_vimeo_download_errback(x, callback, url),
             extra_headers={
                 'Referer': 'http://vimeo.com/%s' % id_,
                 'X-Requested-With': 'XMLHttpRequest',
@@ -328,12 +328,13 @@ def _scrape_vimeo_download_callback(info, callback):
 
     if largest_url is not None:
         callback(u'http://vimeo.com/%s' % largest_url,
-                 content_type='video/mp4')
+                 content_type=u'video/mp4')
     else:
-        _scrape_vimeo_download_errback(info, callback, info)
+        _scrape_vimeo_download_errback("no largest url", callback,
+                                       info['original-url'])
 
-def _scrape_vimeo_download_errback(info, callback):
-    logging.exception("Unable to scrape %r", info['original-url'])
+def _scrape_vimeo_download_errback(err, callback, url):
+    logging.warning("Unable to scrape %r\nerror: %s", url, err)
     callback(None)
 
 # =============================================================================

--- a/tv/lib/test/flashscrapertest.py
+++ b/tv/lib/test/flashscrapertest.py
@@ -53,7 +53,8 @@ class VimeoScraper(FlashScraperBase):
         self.run_event_loop()
         self.assertNotEqual(self._response, None)
         self.assertNotEqual(self._response[0], None)
-        self.assertEqual(self._response[1], 'video/mp4')
+        self.assertEqual(type(self._response[1]), unicode)
+        self.assertEqual(self._response[1], u'video/mp4')
 
     @uses_httpclient
     def test_scrape_moogaloop(self):
@@ -63,4 +64,5 @@ class VimeoScraper(FlashScraperBase):
         self.run_event_loop()
         self.assertNotEqual(self._response, None)
         self.assertNotEqual(self._response[0], None)
-        self.assertEqual(self._response[1], 'video/mp4')
+        self.assertEqual(type(self._response[1]), unicode)
+        self.assertEqual(self._response[1], u'video/mp4')


### PR DESCRIPTION
Also, this changes the MIME type returned to be unicode, and tests that it is
so.
