### PR TITLE
Make plugins work on linux.

### DIFF
--- a/tv/linux/plat/frontends/widgets/application.py
+++ b/tv/linux/plat/frontends/widgets/application.py
@@ -143,7 +143,7 @@ class LinuxApplication(Application):
         gobject.set_application_name(app.config.get(prefs.SHORT_APP_NAME))
         os.environ["PULSE_PROP_media.role"] = "video"
 
-        gtk.gdk.threads_init()
+        gobject.threads_init()
         self._setup_webkit()
         associate_protocols(self._get_command())
         gtkdirectorywatch.GTKDirectoryWatcher.install()

--- a/tv/linux/plat/frontends/widgets/webkitbrowser.py
+++ b/tv/linux/plat/frontends/widgets/webkitbrowser.py
@@ -65,11 +65,6 @@ class WebKitEmbed(webkit.WebView):
         webkit.WebView.__init__(self)
         settings = self.get_settings()
 
-        # this disables all plugins -- Miro has problems with the
-        # adobe flash plugin and hangs when the plugin loads and starts
-        # doing things.
-        settings.set_property('enable-plugins', False)
-
         # sets zoom to affect text and images
         self.set_full_content_zoom(True)
 


### PR DESCRIPTION
I'm not sure the ramifications of changing gtk.gdk.threads_init() to
gobject.threads_init(), but it seems correct in theory at least.  We don't
need gtk.gdk.threads_init() unless we access GTK/GDK from separate threads,
which we don't.  And if we did that, we would need a
threads_enter()/threads_leave() pair, which we're not using.

This fixes things for me.  Is it really this easy?
