### PR TITLE
bz17925: Catch ValueError.

### DIFF
--- a/tv/lib/importmedia.py
+++ b/tv/lib/importmedia.py
@@ -102,5 +102,5 @@ def import_itunes_path(path):
         parser.parse(os.path.join(path, ITUNES_XML_FILE))
         music_path = file_path_xlat(handler.music_path)
         return music_path
-    except (IOError, xml.sax.SAXParseException):
+    except (ValueError, IOError, xml.sax.SAXParseException):
         pass


### PR DESCRIPTION
Can be thrown from invalid url type.

We can skip the test to only run on mac/windows, but we want to keep the code portable.  Besides if ValueError can really be thrown then we should catch it.
