### PR TITLE
bz19228: fix errors with the retry_time column.

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3894,7 +3894,7 @@ def upgrade182(cursor):
     cursor.execute("ALTER TABLE remote_downloader "
                    "ADD COLUMN type text")
     cursor.execute("ALTER TABLE remote_downloader "
-                   "ADD COLUMN retry_time integer")
+                   "ADD COLUMN retry_time timestamp")
     cursor.execute("ALTER TABLE remote_downloader "
                    "ADD COLUMN retry_count integer")
     cursor.execute("ALTER TABLE remote_downloader "
@@ -3927,8 +3927,8 @@ def upgrade182(cursor):
                   ", ".join("%s=? " % name for name in columns))
     for id_, status_repr in cursor.fetchall():
         try:
-            status = eval(status_repr, {}, {})
-        except StandardErrror:
+            status = eval(status_repr, {}, {'datetime': datetime})
+        except StandardError:
             logging.warn("Error evaluating status repr: %r" % status_repr)
             continue
         values = []

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -612,7 +612,7 @@ class RemoteDownloaderSchema(DDBObjectSchema):
         ('reason_failed', SchemaString(noneOk=True)),
         ('short_reason_failed', SchemaString(noneOk=True)),
         ('type', SchemaString(noneOk=True)),
-        ('retry_time', SchemaInt(noneOk=True)),
+        ('retry_time', SchemaDateTime(noneOk=True)),
         ('retry_count', SchemaInt(noneOk=True)),
         ('upload_size', SchemaInt(noneOk=True)),
         ('info_hash', SchemaString(noneOk=True)),


### PR DESCRIPTION
Fixed crash when we failed to unpickle status because I spelled
"StandardError" wrong.

Fixed the underlying issue which was that we needed to support unpickling
datetimes in the database upgrade.

Lastly, fix the column type for retry_time so that it actually works.
