### PR TITLE
bz19231: fix descriptions for migrated items.

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -3966,3 +3966,7 @@ def upgrade183(cursor):
 def upgrade184(cursor):
     """Drop the seen column from item."""
     remove_column(cursor, 'item', ['seen'])
+
+def upgrade185(cursor):
+    """Use NULL for empty item descriptions."""
+    cursor.execute("UPDATE item SET description=NULL WHERE description=''")

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -863,7 +863,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 184
+VERSION = 185
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,


### PR DESCRIPTION
Before we were using "" when we didn't have any description data from the
mutagen or other metadata sources.  Change that to None, which is the
standard, and what we use for new items.
