### PR TITLE
bz19273: convert text to utf-8 before sending it to gtk.Label

### DIFF
--- a/tv/lib/frontends/widgets/gtk/simple.py
+++ b/tv/lib/frontends/widgets/gtk/simple.py
@@ -178,7 +178,7 @@ class Label(Widget):
         return self._widget.get_layout().get_pixel_size()[0]
 
     def set_text(self, text):
-        self._widget.set_text(text)
+        self._widget.set_text(text.encode('utf-8'))
 
     def get_text(self):
         return self._widget.get_text().decode('utf-8')


### PR DESCRIPTION
I'm not really sure why it was crashing before, but this seems like a
safe change in any case.
