### PR TITLE
bz19345: Completely remove delayed sharing start feature.

### DIFF
--- a/tv/lib/frontends/widgets/application.py
+++ b/tv/lib/frontends/widgets/application.py
@@ -297,6 +297,7 @@ class Application:
         messages.TrackNewAudioCount().send_to_backend()
         messages.TrackUnwatchedCount().send_to_backend()
         messages.TrackDevices().send_to_backend()
+        messages.TrackSharing().send_to_backend()
 
     def get_main_window_dimensions(self):
         """Override this to provide platform-specific Main Window dimensions.

--- a/tv/lib/messagehandler.py
+++ b/tv/lib/messagehandler.py
@@ -839,6 +839,12 @@ class BackendMessageHandler(messages.MessageHandler):
             self.playlist_tracker.unlink()
             self.playlist_tracker = None
 
+    def handle_track_sharing(self, message):
+        app.sharing_tracker.start_tracking()
+
+    def handle_stop_tracking_sharing(self, message):
+        pass
+
     def handle_sharing_eject(self, message):
         app.sharing_tracker.eject(message.share.id)
 

--- a/tv/lib/messages.py
+++ b/tv/lib/messages.py
@@ -266,6 +266,11 @@ class StopTrackingWatchedFolders(BackendMessage):
     """
     pass
 
+class TrackSharing(BackendMessage):
+    """Start tracking media shares.
+    """
+    pass
+
 class TrackDevices(BackendMessage):
     """Start tracking devices.
     """

--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -419,9 +419,6 @@ def fix_movies_gone(new_movies_directory):
     eventloop.add_urgent_call(check_movies_gone, "check movies gone",
                               kwargs={'check_unmounted': False})
 
-def start_sharing():
-    app.sharing_tracker.start_tracking()
-
 @startup_function
 def finish_backend_startup():
     """Last bit of startup required before we load the frontend.  """
@@ -452,7 +449,6 @@ def on_frontend_started():
             "start downloader daemon")
     eventloop.add_timeout(10, workerprocess.startup,
             "start worker process")
-    eventloop.add_timeout(15, start_sharing, "start sharing")
     eventloop.add_timeout(20, item.start_deleted_checker,
             "start checking deleted items")
     eventloop.add_timeout(30, feed.start_updates, "start feed updates")


### PR DESCRIPTION
Don't delay the sharing start in any way until we think about this further.
I think what's happened is we have tried to delete something before the
sharing's started and so it tries to remove an item which the sharing
manager did not know about.

Since sharing wasn't really designed with that in mind let's just disable it
for now since this is the safest.

(note: don't forget to cherry-pick for 5.0.2 if it looks good!)
