### PR TITLE
Made it so that log warnings trigger errors in the unittest.

### DIFF
--- a/tv/lib/echonest.py
+++ b/tv/lib/echonest.py
@@ -413,6 +413,8 @@ class _EchonestQuery(object):
 
     def _choose_best_7digital_result(self, results):
         """Pick the best 7digital result from a list."""
+        if len(results) == 1:
+            return results[0]
         if self.album_name_from_tags is None:
             logging.warn("_EchonestQuery._choose_best_7digital_result: "
                          "album_name_from_tags is None")

--- a/tv/lib/metadata.py
+++ b/tv/lib/metadata.py
@@ -1259,16 +1259,14 @@ class MetadataManagerBase(signals.SignalEmitter):
         if local_path is not None:
             local_status = MetadataStatus.get_by_path(local_path)
             status.copy_status(MetadataStatus.get_by_path(local_path))
-            self.run_next_processor(status)
             for entry in MetadataEntry.metadata_for_status(local_status):
                 entry_metadata = entry.get_metadata()
                 initial_metadata.update(entry_metadata)
                 MetadataEntry(status, entry.source, entry_metadata,
                               db_info=self.db_info)
-        else:
-            self._run_mutagen(path)
         if status.current_processor is not None:
             self.count_tracker.file_started(path, initial_metadata)
+            self.run_next_processor(status)
         self._run_update_caller.call_after_timeout(self.UPDATE_INTERVAL)
         self._send_net_lookup_counts_caller.call_when_idle()
         return initial_metadata

--- a/tv/lib/storedatabase.py
+++ b/tv/lib/storedatabase.py
@@ -484,7 +484,7 @@ class LiveStorage(signals.SignalEmitter):
             self.cursor.execute("PRAGMA journal_mode=wal");
         # check that we actually succesfully switch to wal mode
         actual_mode = self.cursor.fetchall()[0][0]
-        if actual_mode != u'wal':
+        if actual_mode != u'wal' and not hasattr(app, 'in_unit_tests'):
             logging.warn("PRAGMA journal_mode=wal didn't change the "
                          "mode.  journal_mode=%s", actual_mode)
 
@@ -821,8 +821,7 @@ class LiveStorage(signals.SignalEmitter):
             try:
                 schema_item.validate(value)
             except schema.ValidationError:
-                if util.chatter:
-                    logging.warn("error validating %s for %s", name, obj)
+                logging.warn("error validating %s for %s", name, obj)
                 raise
             values.append(self._converter.to_sql(obj_schema, name,
                 schema_item, value))
@@ -871,8 +870,7 @@ class LiveStorage(signals.SignalEmitter):
             try:
                 schema_item.validate(value)
             except schema.ValidationError:
-                if util.chatter:
-                    logging.warn("error validating %s for %s", name, obj)
+                logging.warn("error validating %s for %s", name, obj)
                 raise
             values.append(self._converter.to_sql(obj_schema, name,
                 schema_item, value))

--- a/tv/lib/test/databasesanitytest.py
+++ b/tv/lib/test/databasesanitytest.py
@@ -40,7 +40,7 @@ class SanityCheckingTest(MiroTestCase):
     def test_phantom_feed_checking(self):
         f = feed.Feed(u"http://feed.uk")
         i = item.Item(item.FeedParserValues({}), feed_id=f.id)
-        i2 = item.FileItem(FilenameType('/foo/bar.txt'), feed_id=f.id)
+        i2 = item.FileItem(self.make_temp_path('.txt'), feed_id=f.id)
         self.check_object_list_fails_test([i])
         self.check_fix_if_possible([i, i2], [])
         self.check_object_list_passes_test([i, f])

--- a/tv/lib/test/databasetest.py
+++ b/tv/lib/test/databasetest.py
@@ -197,7 +197,8 @@ class DDBObjectTestCase(MiroTestCase):
 
     def test_remove_in_setup_new(self):
         self.assertEquals(TestDDBObject.make_view().count(), 0)
-        TestDDBObject(self, remove=True)
+        with self.allow_warnings():
+            TestDDBObject(self, remove=True)
         self.assertEquals(TestDDBObject.make_view().count(), 0)
 
     def test_test_attribute_track(self):

--- a/tv/lib/test/devicestest.py
+++ b/tv/lib/test/devicestest.py
@@ -136,7 +136,8 @@ target1 = DeviceInfo("Target1")
 devices = [target1]
 """)
         dm = devices.DeviceManager()
-        dm.load_devices(os.path.join(self.tempdir, "*.py"))
+        with self.allow_warnings():
+            dm.load_devices(os.path.join(self.tempdir, "*.py"))
         self.assertRaises(KeyError, dm.get_device, "Target1")
         self.assertRaises(KeyError, dm.get_device_by_id, 0, 0)
 
@@ -252,10 +253,10 @@ class DeviceHelperTest(MiroTestCase):
         with open(os.path.join(self.tempdir, '.miro', 'json'), 'w') as f:
             f.write('NOT JSON DATA')
 
-        ddb = devices.load_database(self.tempdir)
+        with self.allow_warnings():
+            ddb = devices.load_database(self.tempdir)
         self.assertEqual(dict(ddb), {})
         self.assertEqual(len(ddb.get_callbacks('changed')), 1)
-
 
     def test_write_database(self):
         data = {u'a': 2,
@@ -388,7 +389,8 @@ class DeviceDatabaseTest(MiroTestCase):
         mock_do_import.side_effect = sqlite3.DatabaseError("Error")
         self.device.database.created_new = False
         with patcher:
-            self.open_database()
+            with self.allow_warnings():
+                self.open_database()
         # check that we created a new sqlite database and added new metadata
         # status rows for the device items
         cursor = self.device.sqlite_database.cursor

--- a/tv/lib/test/extensiontest.py
+++ b/tv/lib/test/extensiontest.py
@@ -146,7 +146,8 @@ class ExtensionHookTest(ExtensionTestBase):
         # setup our mock function to throw an error
         self.mock_hook.side_effect = ValueError("Bad Value")
         # invoke the hook
-        results = api.hook_invoke('test_hook')
+        with self.allow_warnings():
+            results = api.hook_invoke('test_hook')
         # check that the error isn't included in the results and that we
         # logged the exception
         self.log_filter.check_record_count(1)

--- a/tv/lib/test/fastresumetest.py
+++ b/tv/lib/test/fastresumetest.py
@@ -30,7 +30,8 @@ class FastResumeTest(MiroTestCase):
         f = open(filename, 'wb')
         f.close()
         os.chmod(filename, 0)
-        save_fast_resume_data(FAKE_INFO_HASH, FAKE_RESUME_DATA)
+        with self.allow_warnings():
+            save_fast_resume_data(FAKE_INFO_HASH, FAKE_RESUME_DATA)
         # We did not lock down the directory so check save_fast_resume_data
         # nuked the file for us.
         self.assertFalse(os.path.exists(filename))
@@ -45,6 +46,7 @@ class FastResumeTest(MiroTestCase):
         f.close()
         old_mode = os.stat(filename).st_mode
         os.chmod(filename, 0)
-        data = load_fast_resume_data(FAKE_INFO_HASH)
+        with self.allow_warnings():
+            data = load_fast_resume_data(FAKE_INFO_HASH)
         self.assertEquals(data, None)
         os.chmod(filename, old_mode)

--- a/tv/lib/test/feedtest.py
+++ b/tv/lib/test/feedtest.py
@@ -203,68 +203,6 @@ Instead, astronauts have other options.</description>
         self.assertEqual(len(items), 1)
         my_feed.remove()
 
-class MultiFeedExpireTest(FeedTestCase):
-    def write_files(self, subfeed_count, feed_item_count):
-        all_urls = []
-        self.filenames = []
-
-        content = self.make_feed_content(feed_item_count)
-        for i in xrange(subfeed_count):
-            filename = self.make_temp_path()
-            open(filename, 'wb').write(content)
-            all_urls.append(u"file://%s" % filename)
-            self.filenames.append(filename)
-
-        self.url = u'dtv:multi:' + ','.join(all_urls) + "," + 'testquery'
-
-    def rewrite_files(self, feed_item_count):
-        content = self.make_feed_content(feed_item_count)
-        for filename in self.filenames:
-            open(filename, 'wb').write(content)
-
-    def make_feed_content(self, entry_count):
-        # make a feed with a new item and parse it
-        items = []
-        counter = 0
-
-        items.append("""<?xml version="1.0"?>
-<rss version="2.0">
-   <channel>
-      <title>Downhill Battle Pics</title>
-      <link>http://downhillbattle.org/</link>
-      <description>Downhill Battle is a non-profit organization working to \
-support participatory culture and build a fairer music industry.</description>
-      <pubDate>Wed, 16 Mar 2005 12:03:42 EST</pubDate>
-""")
-
-        for x in range(entry_count):
-            counter += 1
-            items.append("""\
-<item>
- <title>Bumper Sticker</title>
- <guid>guid-%s</guid>
- <enclosure url="http://downhillbattle.org/key/gallery/%s.mpg" />
- <description>I'm a musician and I support filesharing.</description>
-</item>
-""" % (counter, counter))
-
-        items.append("""
-   </channel>
-</rss>""")
-        return "".join(items)
-
-    def test_multi_feed_expire(self):
-        # test what happens when a RSSMultiFeed has feeds that
-        # reference the same item, and they are truncated at the same
-        # time (#11756)
-
-        self.write_files(5, 10) # 5 feeds containing 10 identical items
-        self.feed = self.make_feed()
-        app.config.set(prefs.TRUNCATE_CHANNEL_AFTER_X_ITEMS, 4)
-        app.config.set(prefs.MAX_OLD_ITEMS_DEFAULT, 5)
-        self.rewrite_files(1) # now only 5 items in each feed
-        self.update_feed(self.feed)
-
 class EnclosureFeedTestCase(FeedTestCase):
     def setUp(self):
         FeedTestCase.setUp(self)

--- a/tv/lib/test/httpclienttest.py
+++ b/tv/lib/test/httpclienttest.py
@@ -611,13 +611,17 @@ class HTTPAuthTest(HTTPClientTestBase):
         self.check_auth_canceled()
 
         self.setup_answer("wronguser", "wrongpass")
-        self.grab_url(self.httpserver.build_url('digest-protected/index.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected/index.txt'))
         self.check_auth_errback_called()
 
     @uses_httpclient
     def test_digest_auth_correct(self):
         self.setup_answer("user", "password")
-        self.grab_url(self.httpserver.build_url('digest-protected/index.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected/index.txt'))
         self.assertEquals(self.dialogs_seen, 1)
 
     @uses_httpclient
@@ -634,20 +638,29 @@ class HTTPAuthTest(HTTPClientTestBase):
     @uses_httpclient
     def test_digest_auth_memory(self):
         self.setup_answer("user", "password")
-        self.grab_url(self.httpserver.build_url('digest-protected/index.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected/index.txt'))
         self.assertEquals(self.dialogs_seen, 1)
         # We shouldn't see another dialog for the same URL
-        self.grab_url(self.httpserver.build_url('digest-protected/index.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected/index.txt'))
         self.assertEquals(self.dialogs_seen, 1)
         # ditto for ones in the same directory
-        self.grab_url(self.httpserver.build_url('digest-protected/index2.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected/index2.txt'))
         self.assertEquals(self.dialogs_seen, 1)
         # Even for ones in a subdirectory
-        self.grab_url(self.httpserver.build_url(
-                'digest-protected/foo/index2.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected/foo/index2.txt'))
         self.assertEquals(self.dialogs_seen, 1)
         # Or even for ones outside the directory (only true for digest auth)
-        self.grab_url(self.httpserver.build_url('digest-protected2/index.txt'))
+        with self.allow_warnings():
+            self.grab_url(
+                self.httpserver.build_url('digest-protected2/index.txt'))
         self.assertEquals(self.dialogs_seen, 1)
 
     @uses_httpclient
@@ -719,7 +732,8 @@ class HTTPAuthTest(HTTPClientTestBase):
         self.expecting_errback = True
 
         # test when schemes that aren't "basic" or "digest"
-        self.grab_url(self.httpserver.build_url('invalid-auth/badscheme'))
+        with self.allow_warnings():
+            self.grab_url(self.httpserver.build_url('invalid-auth/badscheme'))
         self.assert_(isinstance(self.grab_url_error,
             httpclient.AuthorizationFailed))
         # when we get invalid auth headers, we shouldn't pop up dialogs for
@@ -727,19 +741,22 @@ class HTTPAuthTest(HTTPClientTestBase):
         self.assertEquals(self.dialogs_seen, 0)
 
         # test auth header without realm
-        self.grab_url(self.httpserver.build_url('invalid-auth/norealm'))
+        with self.allow_warnings():
+            self.grab_url(self.httpserver.build_url('invalid-auth/norealm'))
         self.assert_(isinstance(self.grab_url_error,
             httpclient.AuthorizationFailed))
         self.assertEquals(self.dialogs_seen, 0)
 
         # test completely garbled auth header
-        self.grab_url(self.httpserver.build_url('invalid-auth/garbled'))
+        with self.allow_warnings():
+            self.grab_url(self.httpserver.build_url('invalid-auth/garbled'))
         self.assert_(isinstance(self.grab_url_error,
             httpclient.AuthorizationFailed))
         self.assertEquals(self.dialogs_seen, 0)
 
         # test auth header with no data
-        self.grab_url(self.httpserver.build_url('invalid-auth/'))
+        with self.allow_warnings():
+            self.grab_url(self.httpserver.build_url('invalid-auth/'))
         self.assert_(isinstance(self.grab_url_error,
             httpclient.AuthorizationFailed))
         self.assertEquals(self.dialogs_seen, 0)
@@ -1046,7 +1063,8 @@ class NetworkErrorTest(HTTPClientTestBase):
         options = httpclient.TransferOptions("http://example.com/")
         bogus_transfer = httpclient.CurlTransfer(options,
                 self.grab_url_callback, self.grab_url_errback)
-        bogus_transfer.on_error(123456, BogusLibcurlHandle())
+        with self.allow_warnings():
+            bogus_transfer.on_error(123456, BogusLibcurlHandle())
         self.runPendingIdles()
 
         # Check that we saw a NetworkError and that the description strings

--- a/tv/lib/test/itemtest.py
+++ b/tv/lib/test/itemtest.py
@@ -277,7 +277,8 @@ class DeletedItemTest(MiroTestCase):
         # cause a crash.  A soft failure is okay though.
         app.controller.failed_soft_okay = True
         Item._allow_nonexistent_paths = False
-        FileItem("/non/existent/path/", feed.id)
+        with self.allow_warnings():
+            FileItem("/non/existent/path/", feed.id)
 
 class HaveItemForPathTest(MiroTestCase):
     def setUp(self):
@@ -287,11 +288,14 @@ class HaveItemForPathTest(MiroTestCase):
         self.deleted_paths = []
 
     def add_item(self, filename):
-        path = '/videos/' + unicode_to_filename(filename)
+        path = os.path.join(self.tempdir, unicode_to_filename(filename))
+        # create a bogus file so we don't get a warning when we create a
+        # filename.
+        open(path, 'wb').write("data")
         self.added_items[path] = FileItem(path, self.feed.id)
 
     def remove_item(self, filename):
-        path = '/videos/' + unicode_to_filename(filename)
+        path = os.path.join(self.tempdir, unicode_to_filename(filename))
         self.added_items[path].remove()
         del self.added_items[path]
         self.deleted_paths.append(path)

--- a/tv/lib/test/messagetest.py
+++ b/tv/lib/test/messagetest.py
@@ -626,7 +626,8 @@ class ItemInfoCacheErrorTest(MiroTestCase):
         # insert bogus values into the db
         app.db.cursor.execute("UPDATE item_info_cache SET pickle='BOGUS'")
         # this should fallback to the failsafe values
-        self.setup_new_item_info_cache()
+        with self.allow_warnings():
+            self.setup_new_item_info_cache()
         for item in self.items:
             cache_info = app.item_info_cache.id_to_info[item.id]
             real_info = itemsource.DatabaseItemSource._item_info_for(item)
@@ -666,7 +667,8 @@ class ItemInfoCacheErrorTest(MiroTestCase):
         Item.setup_restored = new_setup_restored
         try:
             # load up item_info_cache
-            self.setup_new_item_info_cache()
+            with self.allow_warnings():
+                self.setup_new_item_info_cache()
         finally:
             Item.setup_restored = old_setup_restored
         cached_info = self.get_info_from_item_info_cache(self.items[0].id)
@@ -701,6 +703,6 @@ class ItemInfoCacheErrorTest(MiroTestCase):
         itemsource.DatabaseItemSource.VERSION += 1
         # We should delete the old cache data because ItemInfoCache.VERSION
         # has changed
-        self.setup_new_item_info_cache()
+        self.setup_new_item_info_cache(set_version=False)
         app.db.cursor.execute("SELECT COUNT(*) FROM item_info_cache")
         self.assertEquals(app.db.cursor.fetchone()[0], 0)

--- a/tv/lib/test/schedulertest.py
+++ b/tv/lib/test/schedulertest.py
@@ -53,7 +53,7 @@ class SchedulerTest(EventLoopTest):
         for i in range(threadCount):
             t = threading.Thread(target=thread)
             t.start()
-        eventloop.add_timeout(1, self.callback, "foo", kwargs={'stop':1})
+        eventloop.add_timeout(1.2, self.callback, "foo", kwargs={'stop':1})
         self.runEventLoop()
         totalCalls = len(timeouts) * threadCount + 1
         self.assertEquals(len(self.got_args), totalCalls)

--- a/tv/lib/test/subprocesstest.py
+++ b/tv/lib/test/subprocesstest.py
@@ -156,7 +156,8 @@ class SubprocessManagerTest(EventLoopTest):
         self.responder.subprocess_events_saw = []
         self.subprocess.process.terminate()
         self.responder.subprocess_ready = False
-        self._wait_for_subprocess_ready()
+        with self.allow_warnings():
+            self._wait_for_subprocess_ready()
         # the subprocess should see a startup
         self.assertEqual(self.responder.subprocess_events_saw, ['startup'])
         # the main process should see a startup and a restart
@@ -177,7 +178,8 @@ class SubprocessManagerTest(EventLoopTest):
         self.subprocess.process.terminate()
         # wait a bit for the subprocess to quit then restart
         self.responder.subprocess_ready = False
-        self._wait_for_subprocess_ready()
+        with self.allow_warnings():
+            self._wait_for_subprocess_ready()
         # test that process #1 has been restarted
         self.assert_(self.subprocess.is_running)
         self.assert_(self.subprocess.process.poll() is None)
@@ -197,7 +199,8 @@ class SubprocessManagerTest(EventLoopTest):
         subprocessmanager._dump_obj(None, self.subprocess.process.stdin)
         # wait a bit for the subprocess to quit then restart
         self.responder.subprocess_ready = False
-        self._wait_for_subprocess_ready()
+        with self.allow_warnings():
+            self._wait_for_subprocess_ready()
         # test that process #1 has been restarted
         self.assert_(self.subprocess.is_running)
         self.assert_(self.subprocess.process.poll() is None)
@@ -300,7 +303,8 @@ class FeedParserTest(WorkerProcessTest):
         original_pid = workerprocess._subprocess_manager.process.pid
         self.send_feedparser_task()
         workerprocess._subprocess_manager.process.terminate()
-        self.runEventLoop(4.0)
+        with self.allow_warnings():
+            self.runEventLoop(4.0)
         # check that we really restarted the subprocess
         self.assertNotEqual(original_pid,
                 workerprocess._subprocess_manager.process.pid)
@@ -364,6 +368,7 @@ class MovieDataTest(WorkerProcessTest):
         self.check_movie_data_call('mp3-1.mp3', 'audio', 1044, False)
         self.check_movie_data_call('mp3-2.mp3', 'audio', 1044, False)
 
+    @only_on_platforms('linux', 'win32')
     def test_movie_data_worker_process_video(self):
         self.check_movie_data_call('theora_with_ogg_extension.ogg', 'video',
                                    1044, True)

--- a/tv/lib/test/subscriptiontest.py
+++ b/tv/lib/test/subscriptiontest.py
@@ -198,7 +198,8 @@ class TestSubscription(MiroTestCase):
 class Testfind_subscribe_links(MiroTestCase):
     def test_garbage(self):
         url = 5
-        self.assertEquals(subscription.find_subscribe_links(url), [])
+        with self.allow_warnings():
+            self.assertEquals(subscription.find_subscribe_links(url), [])
 
     def test_different_host(self):
         url = 'http://youtoob.com'

--- a/tv/lib/test/unicodetest.py
+++ b/tv/lib/test/unicodetest.py
@@ -75,7 +75,7 @@ class UnicodeFeedTestCase(framework.EventLoopTest):
      <link>http://participatoryculture.org/boguslink</link>
          <description>\u25cb\u4e00\u4e8c\u4e09\u56db\u4e94\u516d\u4e03\u516b\
 \u4e5d</description>
-        <enclosure url="file://crap" length="0" type="video/mpeg"/>
+             <enclosure url="http://example.com/video.mpeg" length="0" type="video/mpeg"/>
          <pubDate>Fri, 25 Aug 2006 17:39:21 GMT</pubDate>
       </item>
    </channel>
@@ -125,7 +125,7 @@ class UnicodeFeedTestCase(framework.EventLoopTest):
          <title>H\xe4ppy Birthday</title>
          <link>http://participatoryculture.org/boguslink</link>
          <description>H\xe4ppy Birthday</description>
-         <enclosure url="file://crap" length="0" type="video/mpeg"/>
+             <enclosure url="http://example.com/video.mpeg" length="0" type="video/mpeg"/>
          <pubDate>Fri, 25 Aug 2006 17:39:21 GMT</pubDate>
       </item>
    </channel>

--- a/tv/lib/test/utiltest.py
+++ b/tv/lib/test/utiltest.py
@@ -1006,8 +1006,9 @@ class TestBackupSupportDir(MiroTestCase):
         # check that we don't max an archive file too much bigger than our max
         # size
         max_size = 1000000 # 1MB
-        backup = util.SupportDirBackup(self.support_dir, self.skip_dirs,
-                                       max_size=max_size)
+        with self.allow_warnings():
+            backup = util.SupportDirBackup(self.support_dir, self.skip_dirs,
+                                           max_size=max_size)
         filesize = os.stat(backup.backupfile).st_size
         self.assertTrue(filesize <= 1100000,
                         "Backup file too big.  filesize: %s max_size: %s" %

--- a/tv/lib/test/xhtmltest.py
+++ b/tv/lib/test/xhtmltest.py
@@ -89,7 +89,8 @@ class Test_url_encode_dict(MiroTestCase):
 
         # test non string items--these log a warning, but otherwise
         # produce nothing
-        self.assertEquals(urlencodedict({"a": 1}), "")
+        with self.allow_warnings():
+            self.assertEquals(urlencodedict({"a": 1}), "")
 
         # test weird stuff
         self.assertEquals(urlencodedict({"a": "<foo>&blah;\'\""}), 


### PR DESCRIPTION
I this makes them more rebust and also easier to work with since when the
point where the warning is logged is often the best clue to what's going
wrong.

Fixed a couple of small bugs related to warnings.
- echonest -- don't log a warning in _choose_best_7digital_result() if the
  is only 1 result to choose from which happens when we send a enfmp code
  echonest.
- storedatabase -- don't log a warning if we can't swich to WAL mode in th
  unittests (this happens currently on 10.6, which has an older version of
  sqlite3)
- metadata -- don't call file_finished() for metadata objects that we are
  creating and not running any metadata processor on.  (happens when we
  clone the metdada entries for a synced file)
- storedatabase -- always log warnings when schema validation fails.  Befo
  we were skipping this for unittests, but I think it's better that this
  triggers an error.  We will probably trigger an error later anyway and w
  have the best information at this point.

Also a couple of unittest fixes:
- Don't run the moviedata video test on osx.  Not sure why it wasn't working,
  but I guess there's an issue with theora files.
- Set the item-info-cache version before loading it.
- Removed the multi-feed test.  We don't have multi-feed handling code
  anymore, we just use it as a base class.
- increased the timeout slightly inside ScheduleTest
