### PR TITLE
Fixed SQL triggers that insert values into item_fts

### DIFF
--- a/tv/lib/databaseupgrade.py
+++ b/tv/lib/databaseupgrade.py
@@ -4113,3 +4113,27 @@ def upgrade189(cursor):
                    (column_list, column_list))
     # The triggers are still present even though we dropped item_fts, no need
     # to re-make them.
+
+def upgrade190(cursor):
+    """Fix item triggers after update189"""
+    # update189 incorrectly assumed that the item triggers from before were
+    # still correct.  We need to redo a couple of them since the columns in
+    # item_fts changed
+
+    columns = ['title', 'description', 'artist', 'album', 'genre',
+               'filename', 'parent_title', ]
+    column_list = ', '.join(c for c in columns)
+    column_list_for_new = ', '.join("new.%s" % c for c in columns)
+    cursor.execute("DROP TRIGGER item_au")
+    cursor.execute("CREATE TRIGGER item_au "
+                   "AFTER UPDATE ON item BEGIN "
+                   "INSERT INTO item_fts(docid, %s) "
+                   "VALUES(new.id, %s); "
+                   "END;" % (column_list, column_list_for_new))
+
+    cursor.execute("DROP TRIGGER item_ai")
+    cursor.execute("CREATE TRIGGER item_ai "
+                   "AFTER INSERT ON item BEGIN "
+                   "INSERT INTO item_fts(docid, %s) "
+                   "VALUES(new.id, %s); "
+                   "END;" % (column_list, column_list_for_new))

--- a/tv/lib/schema.py
+++ b/tv/lib/schema.py
@@ -871,7 +871,7 @@ class MetadataEntrySchema(DDBObjectSchema):
         ('metadata_entry_status_and_source', ('status_id', 'source')),
     )
 
-VERSION = 189
+VERSION = 190
 
 object_schemas = [
     IconCacheSchema, ItemSchema, FeedSchema,

--- a/tv/lib/test/storedatabasetest.py
+++ b/tv/lib/test/storedatabasetest.py
@@ -207,6 +207,23 @@ class DBUpgradeTest(StoreDatabaseTest):
         self.assertEquals(upgraded_db_indexes, blank_db_indexes)
 
     @skip_for_platforms('win32')
+    def test_triggers_same(self):
+        # this fails on windows because it's using a non-Windows
+        # database
+        self.remove_database()
+        self.reload_database()
+        app.db.cursor.execute("SELECT name, sql FROM main.sqlite_master "
+                              "WHERE type='trigger'")
+        blank_db_indexes = set(app.db.cursor)
+        shutil.copy(resources.path("testdata/olddatabase.v79"),
+                    self.save_path2)
+        self.reload_database(self.save_path2)
+        app.db.cursor.execute("SELECT name, sql FROM main.sqlite_master "
+                              "WHERE type='trigger'")
+        upgraded_db_indexes = set(app.db.cursor)
+        self.assertEquals(upgraded_db_indexes, blank_db_indexes)
+
+    @skip_for_platforms('win32')
     def test_schema_same(self):
         # this fails on windows because it's using a non-Windows
         # database


### PR DESCRIPTION
If the user upgraded their database, we weren't copying the parent_title text
over.

Added a unittest to check this in the future.
