### PR TITLE
Use g_object_install_property instead of g_object_install_properties

### DIFF
--- a/tv/lib/frontends/widgets/gtk/fixedliststore/README
+++ b/tv/lib/frontends/widgets/gtk/fixedliststore/README
@@ -17,5 +17,5 @@ fixed-list-store-wrapper.c:
 
 fixed-list-store-module.c defines the module that stores the wrapper code.
 
-Lastly there's setup-test.py and setup.py which work together to build a quick
+Lastly there's setup-test.py and test.py which work together to build a quick
 python program to test the code.

--- a/tv/lib/frontends/widgets/gtk/fixedliststore/fixed-list-store.c
+++ b/tv/lib/frontends/widgets/gtk/fixedliststore/fixed-list-store.c
@@ -171,9 +171,9 @@ miro_fixed_list_store_class_init (MiroFixedListStoreClass *klass)
 
     gobject_class->set_property = miro_fixed_list_store_set_property;
     gobject_class->get_property = miro_fixed_list_store_get_property;
-    g_object_class_install_properties (gobject_class,
-                                       N_PROPERTIES,
-                                       obj_properties);
+    g_object_class_install_property (gobject_class,
+                                     PROP_ROW_COUNT,
+                                     obj_properties[PROP_ROW_COUNT]);
 }
 
 static void

--- a/tv/lib/frontends/widgets/gtk/fixedliststore/test.py
+++ b/tv/lib/frontends/widgets/gtk/fixedliststore/test.py
@@ -16,8 +16,8 @@ for dirname in ("build", "dist"):
     if os.path.exists(dirname):
         shutil.rmtree(dirname)
 subprocess.check_call(["python",  "test-setup.py", "install", "--prefix", "dist"])
-#subprocess.check_call(["touch", "build/lib.linux-x86_64-2.7/miro/__init__.py"])
-sys.path.append("dist/lib/python2.7/site-packages/")
+sys.path.append("dist/lib/python%s.%s/site-packages/" %
+		(sys.version_info[0], sys.version_info[1]))
 
 print 'running...'
 print


### PR DESCRIPTION
It's basically the same and the single-property version works with older
libgobject versions.

Also made some fixes to the fixedliststore README and testing script.
