### PR TITLE
bz19442: Allow building on OS X 10.8.

### DIFF
--- a/tv/osx/build.sh
+++ b/tv/osx/build.sh
@@ -37,10 +37,10 @@ if [ ! -d "miro-binary-kit-osx-${BKIT_VERSION}" ]; then
     exit 1
 fi
 
-if [[ $OS_VERSION == "10" ]] || [[ $OS_VERSION == "11" ]]; then
+if [[ $OS_VERSION == "10" ]] || [[ $OS_VERSION == "11" || $OS_VERSION == "12" ]]; then
     TARGET_OS_VERSION=10.6
 else
-    echo "Building and running Miro is only supported on Mac OS X 10.6 and 10.7."
+    echo "Building and running Miro is only supported on Mac OS X 10.{6,7,8}."
     exit 1
 fi
 

--- a/tv/osx/setup_sandbox.sh
+++ b/tv/osx/setup_sandbox.sh
@@ -39,10 +39,10 @@ BKIT_VERSION="$(cat binary_kit_version)"
 # =============================================================================
 
 OS_VERSION=$(uname -r | cut -d . -f 1)
-if [[ $OS_VERSION == "10" ]] || [[ $OS_VERSION == "11" ]]; then
+if [[ $OS_VERSION == "10" ]] || [[ $OS_VERSION == "11" ]] || [[ $OS_VERSION == "12" ]]; then
     TARGET_OS_VERSION=10.6
 else
-    echo "## This script can only be used under Mac OS X 10.6 and 10.7."
+    echo "## This script can only be used under Mac OS X 10.{6,7,8}."
     exit 1
 fi
 


### PR DESCRIPTION
Update the static check in the build scripts so we can build on
OS X 10.8 too.
