### PR TITLE
bz19441: Relink the py2app application stub with Cocoa and AppKit.

### DIFF
--- a/tv/osx/setup_sandbox.sh
+++ b/tv/osx/setup_sandbox.sh
@@ -191,6 +191,13 @@ do
             patch -p0 < $patch_file
         done
     fi
+
+    # For py2app: make sure we rebuild the patched main.c executables.
+    if [[ -d $WORK_DIR/$pkg/py2app/apptemplate ]]; then
+        pushd $WORK_DIR/$pkg/py2app/apptemplate
+            $PYTHON setup.py
+        popd
+    fi
     
     $PYTHON setup.py install
 done


### PR DESCRIPTION
Seems that the sandbox has some trouble finding sandbox services
unless these libraries are dynamically linked in right from the
start in the main executable of the application bundle.
