### PR TITLE
bz19450: don't create the focus-out signal twice on OSX

### DIFF
--- a/tv/osx/plat/frontends/widgets/control.py
+++ b/tv/osx/plat/frontends/widgets/control.py
@@ -210,7 +210,6 @@ class MultilineTextEntry(Widget):
         self.view.setVerticallyResizable_(YES)
         self.notifications = NotificationForwarder.create(self.view)
         self.create_signal('changed')
-        self.create_signal('focus-out')
         if initial_text is not None:
             self.set_text(initial_text)
         self.set_size(widgetconst.SIZE_NORMAL)


### PR DESCRIPTION
It's already created in the base Widget class, so we don't need to also create
it in MultiLineTextEntry.
