### PR TITLE
bz19039: check that we create widgets inside the UI thread

### DIFF
--- a/tv/lib/frontends/widgets/gtk/base.py
+++ b/tv/lib/frontends/widgets/gtk/base.py
@@ -32,6 +32,7 @@
 import gtk
 
 from miro import signals
+from miro import threadcheck
 from miro.frontends.widgets.gtk import wrappermap
 from miro.frontends.widgets.gtk.weakconnect import weak_connect
 from miro.frontends.widgets.gtk import keymap
@@ -54,6 +55,7 @@ class Widget(signals.SignalEmitter):
             allocated.
     """
     def __init__(self, *signal_names):
+        threadcheck.confirm_ui_thread()
         signals.SignalEmitter.__init__(self, *signal_names)
         self.create_signal('size-allocated')
         self.create_signal('key-press')

--- a/tv/lib/startfrontend.py
+++ b/tv/lib/startfrontend.py
@@ -47,9 +47,11 @@ frontend.  It should input these arguments:
 
 import string
 import logging
+import threading
 
 from miro import app
 from miro import startup
+from miro import threadcheck
 
 def load_frontend(globals_, locals_, frontend):
     try:
@@ -84,6 +86,7 @@ def run_application(frontend, props_to_set, theme):
             break
     else:
         raise ValueError("Cannot load frontend: %s" % frontend)
+    threadcheck.set_ui_thread(threading.currentThread())
     application.run_application()
 
 def set_properties(props):

--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -79,6 +79,7 @@ import miro.plat.resources
 from miro.plat.utils import setup_logging, filename_to_unicode
 from miro import tabs
 from miro import theme
+from miro import threadcheck
 from miro import util
 from miro import searchengines
 from miro import storedatabase
@@ -272,7 +273,7 @@ def load_extensions():
 
 @startup_function
 def finish_startup(obj, thread):
-    database.set_thread(thread)
+    threadcheck.set_eventloop_thread(thread)
     logging.info("Installing deleted file checker...")
     item.setup_deleted_checker()
     logging.info("Restoring database...")

--- a/tv/lib/threadcheck.py
+++ b/tv/lib/threadcheck.py
@@ -1,0 +1,71 @@
+# Miro - an RSS based video player application
+# Copyright (C) 2012
+# Participatory Culture Foundation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# In addition, as a special exception, the copyright holders give
+# permission to link the code of portions of this program with the OpenSSL
+# library.
+#
+# You must obey the GNU General Public License in all respects for all of
+# the code used other than OpenSSL. If you modify file(s) with this
+# exception, you may extend this exception to your version of the file(s),
+# but you are not obligated to do so. If you do not wish to do so, delete
+# this exception statement from your version. If you delete this exception
+# statement from all source files in the program, then also delete it here.
+
+"""threadcheck -- check that we are running in the right thread.
+"""
+
+import threading
+import traceback
+
+eventloop_thread = None
+ui_thread = None
+
+class ThreadError(StandardError):
+    """Raised when we are running code in the wrong thread.
+    """
+    pass
+
+def set_eventloop_thread(thread):
+    global eventloop_thread
+    eventloop_thread = thread
+
+def set_ui_thread(thread):
+    global ui_thread
+    ui_thread = thread
+
+def confirm_eventloop_thread():
+    """Confirm that we are running in the eventloop thread.
+
+    If we aren't then a ThreadError will be raised
+    """
+    _confirm_thread(eventloop_thread, 'Eventloop thread')
+
+def confirm_ui_thread():
+    """Confirm that we are running in the UI thread.
+
+    If we aren't then a ThreadError will be raised
+    """
+    _confirm_thread(ui_thread, 'UI thread')
+
+def _confirm_thread(correct_thread, thread_name):
+    if correct_thread is None:
+        raise ThreadError("%s not set" % thread_name)
+    if correct_thread != threading.currentThread():
+        raise ThreadError("Code running in %s instead of the %s" %
+                          (threading.currentThread(), thread_name))

--- a/tv/osx/plat/frontends/widgets/base.py
+++ b/tv/osx/plat/frontends/widgets/base.py
@@ -35,6 +35,7 @@ from objc import YES, NO, nil
 
 from miro import app
 from miro import signals
+from miro import threadcheck
 from miro.plat.frontends.widgets import wrappermap
 from miro.plat.frontends.widgets.viewport import Viewport, BorrowedViewport
 
@@ -53,6 +54,7 @@ class Widget(signals.SignalEmitter):
     CREATES_VIEW = True 
 
     def __init__(self):
+        threadcheck.confirm_ui_thread()
         signals.SignalEmitter.__init__(self)
         self.create_signal('key-press')
         self.create_signal('focus-out')


### PR DESCRIPTION
Moved code that checks if we are running in the event loop thread from
database.py to a new module.  Added code to check if we are running in the UI
thread as well.

This code has the side effect of raising an exception if a widget gets created
before the gtk.main() or NSApplicationMain() is called.  I'm pretty sure we've
had issues in the past when we didn't do this.
