### PR TITLE
bz19468: fixed opening the item edit dialog.

### DIFF
--- a/tv/lib/frontends/widgets/itemedit.py
+++ b/tv/lib/frontends/widgets/itemedit.py
@@ -325,7 +325,7 @@ class ThumbnailField(DialogOwnerMixin, Field):
     TITLE = _("Choose a thumbnail file")
     DIALOG = widgetset.FileOpenDialog
     def __init__(self, items, label):
-        Field.__init__(self, 'cover_art', items, label)
+        Field.__init__(self, 'cover_art_path', items, label)
         DialogOwnerMixin.__init__(self, self.DIALOG, self.TITLE)
         path = self.common_value
 

--- a/tv/osx/plat/frontends/widgets/simple.py
+++ b/tv/osx/plat/frontends/widgets/simple.py
@@ -191,10 +191,10 @@ class ImageDisplay(Widget):
 
 class ClickableImageButton(ImageDisplay):
     def __init__(self, image_path, max_width=None, max_height=None):
-        ImageDisplay.__init__(self)
-        self.set_border(True)
         self.max_width = max_width
         self.max_height = max_height
+        ImageDisplay.__init__(self)
+        self.set_border(True)
         self.image = None
         self._width, self._height = None, None
         if image_path:


### PR DESCRIPTION
One issue was just an attribute name change.  The other issue was the order we
set things up in ClickableImageButton.
