### PR TITLE
bz19506: convert paths to unicode in items_for_paths()

### DIFF
--- a/tv/lib/devices.py
+++ b/tv/lib/devices.py
@@ -1421,7 +1421,7 @@ def on_new_metadata(metadata_manager, new_metadata, device_id):
     try:
         for path, metadata in new_metadata.iteritems():
             try:
-                device_item = path_map[path]
+                device_item = path_map[path.lower()]
             except KeyError:
                 logging.warn("devices.py - on_new_metadata: Got metadata "
                              "but can't find item for %r", path)

--- a/tv/lib/item.py
+++ b/tv/lib/item.py
@@ -2639,19 +2639,20 @@ class DeviceItem(ItemBase):
     def items_for_paths(cls, path_list, db_info):
         """Get all items for a list of paths.
 
-        :returns: dict mapping paths to DeviceItems.  There will be one entry
-        for each item in path_list that exists in the database.
+        :returns: dict mapping lower-case paths to DeviceItems.  There will be
+        one entry for each item in path_list that exists in the database.
         """
 
+        path_list = [filename_to_unicode(p).lower() for p in path_list]
         path_map = {}
         # It's possible for there to be more than 999 items in path_list.
         # Split up the query to avoid SQLite's host parameters limit
         for paths in util.split_values_for_sqlite(path_list):
             placeholders = ', '.join('?' for i in xrange(len(paths)))
-            view = cls.make_view('filename IN (%s)' % placeholders,
+            view = cls.make_view('lower(filename) IN (%s)' % placeholders,
                                  paths, db_info=db_info)
             for i in view:
-                path_map[i.filename] = i
+                path_map[i.filename.lower()] = i
         return path_map
 
     @classmethod


### PR DESCRIPTION
Also, while I was changing things, I think it makes sense to use
case-insenstive comparisons since that's what we do for the main DB.  It
probably makes even more sense to do it for devices since the filesystem is
less predictable there.
