### PR TITLE
SQL Unicode problems

### DIFF
--- a/tv/lib/frontends/widgets/gtk/simple.py
+++ b/tv/lib/frontends/widgets/gtk/simple.py
@@ -178,7 +178,12 @@ class Label(Widget):
         return self._widget.get_layout().get_pixel_size()[0]
 
     def set_text(self, text):
-        self._widget.set_text(text.encode('utf-8'))
+        if isinstance(text, basestring):
+            self._widget.set_text(text.encode('utf-8'))
+        elif text is None:
+            self._widget.set_text("Title Unknown")
+        else:
+            self._widget.set_text(text)
 
     def get_text(self):
         return self._widget.get_text().decode('utf-8')

--- a/tv/lib/storedatabase.py
+++ b/tv/lib/storedatabase.py
@@ -1054,6 +1054,14 @@ class LiveStorage(signals.SignalEmitter):
 
     def query_ids(self, table_name, where, values=None, order_by=None,
             joins=None, limit=None):
+        # The values need to be converted to unicode in oder to work with
+        # Sqlalchemy. Therefore the tuple must first be converted to a list
+        values = list(values)
+        for x in range(len(values)):
+            if isinstance(values[x], basestring):  # if its a string
+                values[x] = values[x].decode("utf-8")
+        values = tuple(values)
+
         sql = StringIO()
         sql.write("SELECT %s.id " % table_name)
         sql.write(self._get_query_bottom(table_name, where, joins,


### PR DESCRIPTION
When connecting my device (with German titles on it) miro would always crash on me with the following exception: https://gist.github.com/4635745
I simply converted the values to unicode and do not get the error anymore. In addition there don't seem to be any unwanted side effects so this seems to be an easy fix.
Your comments on this are very welcome!
