### PR TITLE
Update debian_wheezy.sh script

### DIFF
--- a/tv/linux/helperscripts/debian_wheezy.sh
+++ b/tv/linux/helperscripts/debian_wheezy.sh
@@ -24,8 +24,9 @@ apt-get install \
     libavcodec-dev \
     libavformat-dev \
     libavutil-dev \
-    libboost1.46-dev \
+    libboost1.49-dev \
     libsoup2.4-dev \
+    libsqlite3-dev \
     libtag1-dev \
     libtorrent-rasterbar6 \
     libwebkit-dev \
@@ -39,4 +40,4 @@ apt-get install \
     python-pycurl \
     python-pyrex \
     python-webkit \
-    zlib1g-dev \
+    zlib1g-dev


### PR DESCRIPTION
This fixes a couple of issues I ran into when running the script to
get dependencies to build Miro on Debian Testing.
