### PR TITLE
Fix default first-time handler

### DIFF
--- a/tv/lib/startup.py
+++ b/tv/lib/startup.py
@@ -333,7 +333,7 @@ class StartupChecker(object):
 
         self.check_movies_gone()
 
-    def first_time_handler(callback):
+    def first_time_handler(self, callback):
         """Default handler for first-time startup
 
         install_first_time_handler() replaces this method with the


### PR DESCRIPTION
The default first-time handler is defined as a method, but is missing
the 'self' argument in its signature, which causes a run-time error when
it is called.

This only occurs with front-ends that do not install their own
first-time handlers, for instance the shell front-end.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pculture/miro/426)

<!-- Reviewable:end -->
