### PR TITLE
High Quality Toggle for YouTube

### DIFF
--- a/tv/lib/flashscraper.py
+++ b/tv/lib/flashscraper.py
@@ -152,7 +152,7 @@ def _youtube_callback_step2(info, video_id, callback):
                 prefs.HIGH_QUALITY_DOWNLOADS)
 
         highest_quality = "22"
-        if high_quality_downloads is True:
+        if high_quality_downloads is False:
             highest_quality = "18"
 
         # http://en.wikipedia.org/wiki/YouTube#Quality_and_codecs

--- a/tv/lib/flashscraper.py
+++ b/tv/lib/flashscraper.py
@@ -151,7 +151,9 @@ def _youtube_callback_step2(info, video_id, callback):
         high_quality_downloads = app.config.get(
                 prefs.HIGH_QUALITY_DOWNLOADS)
 
-        highest_quality = if high_quality_downloads "22" else "18"
+        highest_quality = "22"
+        if high_quality_downloads is True:
+            highest_quality = "18"
 
         # http://en.wikipedia.org/wiki/YouTube#Quality_and_codecs
         for fmt, content_type in [(highest_quality, u"video/mp4"),

--- a/tv/lib/flashscraper.py
+++ b/tv/lib/flashscraper.py
@@ -18,7 +18,7 @@
 #
 # In addition, as a special exception, the copyright holders give
 # permission to link the code of portions of this program with the OpenSSL
-# library.
+# library.2
 #
 # You must obey the GNU General Public License in all respects for all of
 # the code used other than OpenSSL. If you modify file(s) with this
@@ -34,6 +34,8 @@ to a media url.
 import logging
 import re
 from miro import httpclient
+from miro import app
+from miro import prefs
 import urlparse
 import cgi
 from xml.dom import minidom
@@ -146,8 +148,13 @@ def _youtube_callback_step2(info, video_id, callback):
 
         logging.debug("fmt_url_map keys: %s", fmt_url_map.keys())
 
+        high_quality_downloads = app.config.get(
+                prefs.HIGH_QUALITY_DOWNLOADS)
+
+        highest_quality = if high_quality_downloads "22" else "18"
+
         # http://en.wikipedia.org/wiki/YouTube#Quality_and_codecs
-        for fmt, content_type in [("22", u"video/mp4"),
+        for fmt, content_type in [(highest_quality, u"video/mp4"),
                                   ("18", u"video/mp4"),
                                   ("5", u"video/x-flv")]:
             if fmt in fmt_url_map:

--- a/tv/lib/frontends/widgets/prefpanel.py
+++ b/tv/lib/frontends/widgets/prefpanel.py
@@ -851,6 +851,10 @@ class DownloadsPanel(PanelBuilder):
         grid.end_line(spacing=6)
         vbox.pack_start(widgetutil.align_left(grid.make_table()))
 
+        cbx = widgetset.Checkbox(_('Download HD video from YouTube'))
+        attach_boolean(cbx, prefs.HIGH_QUALITY_DOWNLOADS)
+        vbox.pack_start(cbx, padding=4)
+
         return vbox
 
 class _MovieDirectoryHelper(object):

--- a/tv/lib/prefs.py
+++ b/tv/lib/prefs.py
@@ -92,6 +92,7 @@ BT_MIN_PORT                 = Pref(key='BitTorrentMinPort',     default=8500,  p
 BT_MAX_PORT                 = Pref(key='BitTorrentMaxPort',     default=8600,  platformSpecific=False)
 UPLOAD_RATIO                = Pref(key='uploadRatio',           default=2.0,   platformSpecific=False)
 LIMIT_UPLOAD_RATIO          = Pref(key='limitUploadRatio',      default=False, platformSpecific=False)
+HIGH_QUALITY_DOWNLOADS      = Pref(key='HighQualityDownloads',  default=True,  platformSpecific=False)
 STARTUP_TASKS_DONE          = Pref(key='startupTasksDone',      default=False, platformSpecific=False)
 CONTINUOUS_VIDEO_PLAYBACK_MODE  = Pref(key='continuousVideoPlaybackMode', default=True, platformSpecific=False)
 CONTINUOUS_MUSIC_PLAYBACK_MODE  = Pref(key='continuousMusicPlaybackMode', default=True, platformSpecific=False)


### PR DESCRIPTION
In response to http://support.getmiro.com/support/discussions/topics/7684, wherein users are requesting the ability to manage their bandwidth usage by downloading lower quality videos, I have tried to implement a checkbox in the downloads preference panel that will reduce the highest quality video format from YouTube from "22" to "18" (720 to 320).

This could easily be applied to other websites as well with little effort.
