### PR TITLE
Fix YouTube downloads not working

### DIFF
--- a/tv/lib/flashscraper.py
+++ b/tv/lib/flashscraper.py
@@ -134,9 +134,7 @@ def _youtube_callback_step2(info, video_id, callback):
         # strip url= from url=xxxxxx, strip trailer.  Strip duplicate params.
         for fmt, stream_map_data in zip(fmt_list, stream_map):
             stream_map = cgi.parse_qs(stream_map_data)
-            url_base = stream_map['url'][0]
-            sig_part = '&signature=' + stream_map['sig'][0]
-            fmt_url_map[fmt] = url_base + sig_part
+            fmt_url_map[fmt] = stream_map['url'][0]
 
         title = params.get("title", ["No title"])[0]
         try:


### PR DESCRIPTION
- Fix youtube videos not downloading, error in the log said key 'sig'
  was not defined.
- Youtube automatically puts the signature in the 'url' param now, not
  as an extra parameter any longer, so 'sig' param is no longer defined.
